### PR TITLE
Use COPY for MySQL Docker entry point setup

### DIFF
--- a/_mysql/Dockerfile
+++ b/_mysql/Dockerfile
@@ -1,3 +1,6 @@
 FROM mysql:8.0.32
 
+# Copy initialization scripts to the appropriate directory
+COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
+
 EXPOSE 3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,6 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=root_bot_buster
       # - MYSQL_DATABASE=playerdata
-    volumes:
-      - ./_mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     ports:
       - 3307:3306
     networks:


### PR DESCRIPTION
Using volumes in docker compose only works when running a local instance of docker.  

Adjusted to use copy to support remote setups of development.