### PR TITLE
Fix committed if returns none to 0

### DIFF
--- a/components/bot_detector/kafka/repositories/players_to_scrape.py
+++ b/components/bot_detector/kafka/repositories/players_to_scrape.py
@@ -51,7 +51,7 @@ class RepoPlayersToScrapeConsumer(ConsumerInterface):
             tp = TopicPartition(topic, partition)
 
             # Get the last offset committed by the consumer
-            committed = await self.consumer.committed(tp)
+            committed = await self.consumer.committed(tp) or 0
 
             # Get the latest offset in the topic
             end_offset = await self.consumer.end_offsets([tp])

--- a/components/bot_detector/kafka/repositories/players_to_scrape.py
+++ b/components/bot_detector/kafka/repositories/players_to_scrape.py
@@ -41,7 +41,7 @@ class RepoPlayersToScrapeConsumer(ConsumerInterface):
         topic = "players.to_scrape"
 
         # Get the list of partitions for the topic
-        partitions = await self.consumer.partitions_for_topic(topic)
+        partitions = self.consumer.partitions_for_topic(topic)
 
         if partitions is None:
             logger.warning("partitions is none")

--- a/components/bot_detector/kafka/repositories/players_to_scrape.py
+++ b/components/bot_detector/kafka/repositories/players_to_scrape.py
@@ -41,7 +41,7 @@ class RepoPlayersToScrapeConsumer(ConsumerInterface):
         topic = "players.to_scrape"
 
         # Get the list of partitions for the topic
-        partitions = self.consumer.partitions_for_topic(topic)
+        partitions = await self.consumer.partitions_for_topic(topic)
 
         if partitions is None:
             logger.warning("partitions is none")

--- a/test/components/bot_detector/kafka/test_players_to_scrape.py
+++ b/test/components/bot_detector/kafka/test_players_to_scrape.py
@@ -7,16 +7,21 @@ from bot_detector.kafka.repositories.players_to_scrape import (
 )
 
 
-@pytest.mark.asyncio
-async def test_get_lag_handles_none_committed(monkeypatch):
-    # Setup a fake Kafka consumer
-    fake_consumer = AsyncMock()
-    fake_consumer.partitions_for_topic = AsyncMock(return_value={0})
+@pytest.fixture
+def fake_consumer():
+    """Fixture to create a fake Kafka consumer with default behavior."""
+    mock_consumer = AsyncMock()
+    mock_consumer.partitions_for_topic = lambda topic: {0}
     tp = TopicPartition("players.to_scrape", 0)
-    fake_consumer.committed = AsyncMock(return_value=None)
-    fake_consumer.end_offsets = AsyncMock(return_value={tp: 10})
+    # These will be overridden in each test if needed
+    mock_consumer.committed = AsyncMock(return_value=None)
+    mock_consumer.end_offsets = AsyncMock(return_value={tp: 10})
+    return mock_consumer
 
-    # Patch the real consumer with the fake
+
+@pytest.mark.asyncio
+async def test_get_lag_handles_none_committed(fake_consumer):
+    # Default committed is None (set in the fixture)
     consumer = RepoPlayersToScrapeConsumer("test-group", ["localhost:9092"])
     consumer.consumer = fake_consumer
 
@@ -25,13 +30,8 @@ async def test_get_lag_handles_none_committed(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_lag_handles_committed_zero(monkeypatch):
-    fake_consumer = AsyncMock()
-    fake_consumer.partitions_for_topic = AsyncMock(return_value={0})
-    tp = TopicPartition("players.to_scrape", 0)
-    fake_consumer.committed = AsyncMock(return_value=0)
-    fake_consumer.end_offsets = AsyncMock(return_value={tp: 10})
-
+async def test_get_lag_handles_committed_zero(fake_consumer):
+    fake_consumer.committed = AsyncMock(return_value=0)  # Override for this test
     consumer = RepoPlayersToScrapeConsumer("test-group", ["localhost:9092"])
     consumer.consumer = fake_consumer
 

--- a/test/components/bot_detector/kafka/test_players_to_scrape.py
+++ b/test/components/bot_detector/kafka/test_players_to_scrape.py
@@ -1,0 +1,39 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from aiokafka.structs import TopicPartition
+from bot_detector.kafka.repositories.players_to_scrape import (
+    RepoPlayersToScrapeConsumer,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_lag_handles_none_committed(monkeypatch):
+    # Setup a fake Kafka consumer
+    fake_consumer = AsyncMock()
+    fake_consumer.partitions_for_topic = AsyncMock(return_value={0})
+    tp = TopicPartition("players.to_scrape", 0)
+    fake_consumer.committed = AsyncMock(return_value=None)
+    fake_consumer.end_offsets = AsyncMock(return_value={tp: 10})
+
+    # Patch the real consumer with the fake
+    consumer = RepoPlayersToScrapeConsumer("test-group", ["localhost:9092"])
+    consumer.consumer = fake_consumer
+
+    lag = await consumer.get_lag()
+    assert lag == 10  # If committed is None, lag should be full length
+
+
+@pytest.mark.asyncio
+async def test_get_lag_handles_committed_zero(monkeypatch):
+    fake_consumer = AsyncMock()
+    fake_consumer.partitions_for_topic = AsyncMock(return_value={0})
+    tp = TopicPartition("players.to_scrape", 0)
+    fake_consumer.committed = AsyncMock(return_value=0)
+    fake_consumer.end_offsets = AsyncMock(return_value={tp: 10})
+
+    consumer = RepoPlayersToScrapeConsumer("test-group", ["localhost:9092"])
+    consumer.consumer = fake_consumer
+
+    lag = await consumer.get_lag()
+    assert lag == 10  # 10-0


### PR DESCRIPTION
```
  File "/app/projects/scrape_task_producer/.venv/lib/python3.11/site-packages/bot_detector/kafka/repositories/players_to_scrape.py", line 60, in get_lag
    lag = end_offset[tp] - committed
          ~~~~~~~~~~~~~~~^~~~~~~~~~~
TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'
```