### PR TITLE
Improve Kafka adapter error typing and add tests to increase coverage

### DIFF
--- a/components/bot_detector/event_queue/adapters/kafka/adapter.py
+++ b/components/bot_detector/event_queue/adapters/kafka/adapter.py
@@ -6,6 +6,14 @@ import orjson
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer, ConsumerRecord
 from aiokafka.errors import KafkaTimeoutError
 from bot_detector.event_queue.core.batcher import Batcher
+from bot_detector.event_queue.core.errors import (
+    ConsumerConfigError,
+    ConsumerFetchError,
+    ConsumerNotStartedError,
+    MessageTypeError,
+    ProducerConfigError,
+    ProducerNotStartedError,
+)
 from bot_detector.event_queue.core.interface import (
     QueueBackendConsumerProtocol,
     QueueBackendProducerProtocol,
@@ -31,7 +39,7 @@ class _AIOKafkaProducerBase(Generic[T]):
 
     def _validate(self, record: ConsumerRecord) -> T | Exception:
         if not isinstance(record.value, dict):
-            return Exception("Message must be of type dict")
+            return MessageTypeError("Message must be of type dict")
         try:
             return self.cls.model_validate(record.value)
         except ValidationError as ve:
@@ -62,9 +70,11 @@ class AIOKafkaProducerAdapter(
 
     async def put(self, messages: list[T]) -> Optional[Exception]:
         if self.producer is None:
-            return Exception("Producer is None, did you start the producer?")
+            return ProducerNotStartedError(
+                "Producer is None, did you start the producer?"
+            )
         if self.config.producer_config is None:
-            return Exception("Producer Configuration is None")
+            return ProducerConfigError("Producer Configuration is None")
         _config = self.config.producer_config
 
         for message in messages:
@@ -108,7 +118,7 @@ class AIOKafkaConsumerAdapter(
 
     async def start(self) -> None:
         if self.config.consumer_config is None:
-            raise Exception("Consumer Configuration is None")
+            raise ConsumerConfigError("Consumer Configuration is None")
         if self.consumer is None:
             _config = self.config.consumer_config
             self.consumer = AIOKafkaConsumer(
@@ -127,11 +137,13 @@ class AIOKafkaConsumerAdapter(
 
     async def get_one(self) -> Optional[T] | Exception:
         if self.consumer is None:
-            return Exception("Consumer is None, did you start the consumer?")
+            return ConsumerNotStartedError(
+                "Consumer is None, did you start the consumer?"
+            )
         try:
             record = await self.consumer.getone()
         except Exception as e:
-            return e
+            return ConsumerFetchError("Failed to fetch message", cause=e)
         if record is None:
             return None
 
@@ -140,9 +152,11 @@ class AIOKafkaConsumerAdapter(
 
     async def get_many(self, count: int) -> list[T] | Exception:
         if self.consumer is None:
-            return Exception("Consumer is None, did you start the consumer?")
+            return ConsumerNotStartedError(
+                "Consumer is None, did you start the consumer?"
+            )
         if self.config.consumer_config is None:
-            return Exception("Consumer Configuration is None")
+            return ConsumerConfigError("Consumer Configuration is None")
         _config = self.config.consumer_config
 
         batcher = Batcher[T](
@@ -160,7 +174,7 @@ class AIOKafkaConsumerAdapter(
                     max_records=count - batcher.size,
                 )
             except Exception as e:
-                return e
+                return ConsumerFetchError("Failed to fetch messages", cause=e)
 
             if not records:
                 await asyncio.sleep(1)  # prevent busy-loop
@@ -176,7 +190,9 @@ class AIOKafkaConsumerAdapter(
 
     async def commit(self) -> Optional[Exception]:
         if self.consumer is None:
-            return Exception("Consumer is None, did you start the consumer?")
+            return ConsumerNotStartedError(
+                "Consumer is None, did you start the consumer?"
+            )
         await self.consumer.commit()
 
 

--- a/components/bot_detector/event_queue/core/errors.py
+++ b/components/bot_detector/event_queue/core/errors.py
@@ -1,0 +1,30 @@
+class EventQueueError(Exception):
+    """Base exception for event queue errors."""
+
+
+class MessageTypeError(EventQueueError):
+    """Raised when a message payload has an unexpected type."""
+
+
+class ProducerNotStartedError(EventQueueError):
+    """Raised when a producer operation happens before start."""
+
+
+class ProducerConfigError(EventQueueError):
+    """Raised when producer configuration is missing or invalid."""
+
+
+class ConsumerNotStartedError(EventQueueError):
+    """Raised when a consumer operation happens before start."""
+
+
+class ConsumerConfigError(EventQueueError):
+    """Raised when consumer configuration is missing or invalid."""
+
+
+class ConsumerFetchError(EventQueueError):
+    """Raised when a consumer fails to fetch messages."""
+
+    def __init__(self, message: str, *, cause: Exception) -> None:
+        super().__init__(message)
+        self.cause = cause

--- a/test/components/bot_detector/event_queue/test_adapter_kafka.py
+++ b/test/components/bot_detector/event_queue/test_adapter_kafka.py
@@ -4,13 +4,23 @@ import orjson
 import pytest
 from aiokafka.errors import KafkaTimeoutError
 from bot_detector.event_queue.adapters.kafka import (
+    AIOKafkaAdapter,
     AIOKafkaConsumerAdapter,
     AIOKafkaProducerAdapter,
     KafkaConfig,
     KafkaConsumerConfig,
     KafkaProducerConfig,
 )
-from pydantic import BaseModel
+from bot_detector.event_queue.core.batcher import Batcher
+from bot_detector.event_queue.core.errors import (
+    ConsumerConfigError,
+    ConsumerFetchError,
+    ConsumerNotStartedError,
+    MessageTypeError,
+    ProducerConfigError,
+    ProducerNotStartedError,
+)
+from pydantic import BaseModel, ValidationError
 
 
 class PlayerScraped(BaseModel):
@@ -307,4 +317,438 @@ async def test_consumer_connection_error():
     adapter.consumer.getone = AsyncMock(side_effect=Exception("boom"))
 
     result = await adapter.get_one()
-    assert isinstance(result, Exception)
+    assert isinstance(result, ConsumerFetchError)
+    assert isinstance(result.cause, Exception)
+
+
+@pytest.mark.asyncio
+async def test_producer_put_without_start():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=False,
+        producer=True,
+        consumer_config=None,
+        producer_config=KafkaProducerConfig(partition_key_fn=lambda: "1"),
+    )
+    adapter = AIOKafkaProducerAdapter(PlayerScraped, config)
+
+    result = await adapter.put([PlayerScraped(id=1, username="Alice", score=100)])
+
+    assert isinstance(result, ProducerNotStartedError)
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_one_without_start():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+
+    result = await adapter.get_one()
+
+    assert isinstance(result, ConsumerNotStartedError)
+
+
+@pytest.mark.asyncio
+async def test_consumer_invalid_message_type():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+
+    fake_record = AsyncMock()
+    fake_record.value = ["not", "a", "dict"]
+
+    adapter.consumer = AsyncMock()
+    adapter.consumer.getone = AsyncMock(return_value=fake_record)
+
+    result = await adapter.get_one()
+
+    assert isinstance(result, MessageTypeError)
+
+
+@pytest.mark.asyncio
+async def test_producer_put_without_config():
+    with patch.object(KafkaConfig, "check_config", lambda self: self):
+        config = KafkaConfig(
+            topic="players",
+            bootstrap_servers="localhost:9092",
+            consumer=False,
+            producer=True,
+            consumer_config=None,
+            producer_config=None,
+        )
+        adapter = AIOKafkaProducerAdapter(PlayerScraped, config)
+        adapter.producer = AsyncMock()
+
+        result = await adapter.put([PlayerScraped(id=1, username="Alice", score=100)])
+
+        assert isinstance(result, ProducerConfigError)
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_many_without_config():
+    with patch.object(KafkaConfig, "check_config", lambda self: self):
+        config = KafkaConfig(
+            topic="players",
+            bootstrap_servers="localhost:9092",
+            consumer=True,
+            producer=False,
+            consumer_config=None,
+            producer_config=None,
+        )
+        adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+        adapter.consumer = AsyncMock()
+
+        result = await adapter.get_many(1)
+
+        assert isinstance(result, ConsumerConfigError)
+
+
+@pytest.mark.asyncio
+async def test_consumer_start_without_config():
+    with patch.object(KafkaConfig, "check_config", lambda self: self):
+        config = KafkaConfig(
+            topic="players",
+            bootstrap_servers="localhost:9092",
+            consumer=True,
+            producer=False,
+            consumer_config=None,
+            producer_config=None,
+        )
+        adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+
+        with pytest.raises(ConsumerConfigError):
+            await adapter.start()
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_many_connection_error():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+    adapter.consumer = AsyncMock()
+    adapter.consumer.getmany = AsyncMock(side_effect=Exception("boom"))
+
+    result = await adapter.get_many(1)
+
+    assert isinstance(result, ConsumerFetchError)
+    assert isinstance(result.cause, Exception)
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_many_invalid_message_type():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+
+    fake_record = AsyncMock()
+    fake_record.value = "not-a-dict"
+
+    adapter.consumer = AsyncMock()
+    adapter.consumer.getmany = AsyncMock(return_value={0: [fake_record]})
+
+    result = await adapter.get_many(1)
+
+    assert isinstance(result, MessageTypeError)
+
+
+@pytest.mark.asyncio
+async def test_consumer_commit_without_start():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+
+    result = await adapter.commit()
+
+    assert isinstance(result, ConsumerNotStartedError)
+
+
+@pytest.mark.asyncio
+async def test_producer_start_noop_when_existing():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=False,
+        producer=True,
+        consumer_config=None,
+        producer_config=KafkaProducerConfig(partition_key_fn=lambda: b"1"),
+    )
+    adapter = AIOKafkaProducerAdapter(PlayerScraped, config)
+    adapter.producer = AsyncMock()
+
+    with patch(
+        "bot_detector.event_queue.adapters.kafka.adapter.AIOKafkaProducer"
+    ) as mock_producer_class:
+        await adapter.start()
+        mock_producer_class.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_producer_stop_noop_when_missing():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=False,
+        producer=True,
+        consumer_config=None,
+        producer_config=KafkaProducerConfig(partition_key_fn=lambda: b"1"),
+    )
+    adapter = AIOKafkaProducerAdapter(PlayerScraped, config)
+
+    await adapter.stop()
+
+
+@pytest.mark.asyncio
+async def test_producer_partition_key_bytes():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=False,
+        producer=True,
+        consumer_config=None,
+        producer_config=KafkaProducerConfig(partition_key_fn=lambda: b"key"),
+    )
+    adapter = AIOKafkaProducerAdapter(PlayerScraped, config)
+
+    with patch(
+        "bot_detector.event_queue.adapters.kafka.adapter.AIOKafkaProducer"
+    ) as mock_producer_class:
+        mock_producer = mock_producer_class.return_value
+        mock_producer.start = AsyncMock()
+        mock_producer.send = AsyncMock()
+        mock_producer.stop = AsyncMock()
+
+        await adapter.start()
+        await adapter.put([PlayerScraped(id=1, username="Alice", score=100)])
+
+        mock_producer.send.assert_called_once_with(
+            topic="players",
+            value=PlayerScraped(id=1, username="Alice", score=100).model_dump(),
+            key=b"key",
+        )
+
+
+@pytest.mark.asyncio
+async def test_producer_partition_key_invalid_type():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=False,
+        producer=True,
+        consumer_config=None,
+        producer_config=KafkaProducerConfig(partition_key_fn=lambda: 123),
+    )
+    adapter = AIOKafkaProducerAdapter(PlayerScraped, config)
+    adapter.producer = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await adapter.put([PlayerScraped(id=1, username="Alice", score=100)])
+
+
+@pytest.mark.asyncio
+async def test_consumer_start_noop_when_existing():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+    adapter.consumer = AsyncMock()
+
+    with patch(
+        "bot_detector.event_queue.adapters.kafka.adapter.AIOKafkaConsumer"
+    ) as mock_consumer_class:
+        await adapter.start()
+        mock_consumer_class.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_consumer_stop_noop_when_missing():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+
+    await adapter.stop()
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_one_validation_error():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+
+    fake_record = AsyncMock()
+    fake_record.value = {"id": 1}
+
+    adapter.consumer = AsyncMock()
+    adapter.consumer.getone = AsyncMock(return_value=fake_record)
+
+    result = await adapter.get_one()
+
+    assert isinstance(result, ValidationError)
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_many_breaks_on_timeout():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+    adapter.consumer = AsyncMock()
+
+    with patch.object(Batcher, "time_left", new=property(lambda self: 0.0)):
+        result = await adapter.get_many(1)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_many_empty_records_sleeps():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group", consume_timeout_ms=5),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+
+    adapter.consumer = AsyncMock()
+    adapter.consumer.getmany = AsyncMock(side_effect=[{}, {}])
+
+    with patch(
+        "bot_detector.event_queue.adapters.kafka.adapter.asyncio.sleep",
+        new=AsyncMock(),
+    ) as mock_sleep, patch.object(
+        Batcher, "check_flush", side_effect=[False, True]
+    ):
+        result = await adapter.get_many(1)
+
+    assert result == []
+    mock_sleep.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_consumer_commit_success():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=False,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=None,
+    )
+    adapter = AIOKafkaConsumerAdapter(PlayerScraped, config)
+    adapter.consumer = AsyncMock()
+
+    await adapter.commit()
+
+    adapter.consumer.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_kafka_adapter_start_stop_and_delegation():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=True,
+        producer=True,
+        consumer_config=KafkaConsumerConfig(group_id="group"),
+        producer_config=KafkaProducerConfig(partition_key_fn=lambda: "1"),
+    )
+    adapter = AIOKafkaAdapter(PlayerScraped, config)
+    adapter.producer.start = AsyncMock()
+    adapter.consumer.start = AsyncMock()
+    adapter.producer.stop = AsyncMock()
+    adapter.consumer.stop = AsyncMock()
+    adapter.producer.put = AsyncMock()
+    adapter.consumer.get_one = AsyncMock(return_value=None)
+    adapter.consumer.get_many = AsyncMock(return_value=[])
+    adapter.consumer.commit = AsyncMock()
+
+    await adapter.start()
+    await adapter.put([PlayerScraped(id=1, username="Alice", score=100)])
+    await adapter.get_one()
+    await adapter.get_many(1)
+    await adapter.commit()
+    await adapter.stop()
+
+    adapter.producer.start.assert_awaited_once()
+    adapter.consumer.start.assert_awaited_once()
+    adapter.producer.stop.assert_awaited_once()
+    adapter.consumer.stop.assert_awaited_once()
+    adapter.producer.put.assert_awaited_once()
+    adapter.consumer.get_one.assert_awaited_once()
+    adapter.consumer.get_many.assert_awaited_once()
+    adapter.consumer.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_kafka_adapter_start_skips_disabled_sides():
+    config = KafkaConfig(
+        topic="players",
+        bootstrap_servers="localhost:9092",
+        consumer=False,
+        producer=False,
+        consumer_config=None,
+        producer_config=None,
+    )
+    adapter = AIOKafkaAdapter(PlayerScraped, config)
+    adapter.producer.start = AsyncMock()
+    adapter.consumer.start = AsyncMock()
+
+    await adapter.start()
+
+    adapter.producer.start.assert_not_awaited()
+    adapter.consumer.start.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Replace generic `Exception` usage in the Kafka adapter with explicit, typed event-queue errors to make failure modes easier to assert and reason about.
- Exercise uncovered branches in `components/bot_detector/event_queue/adapters/kafka/adapter.py` to raise coverage to acceptable levels.
- Keep production `KafkaConfig` validation intact while enabling tests to simulate misconfiguration via mocking where needed.

### Description
- Added `components/bot_detector/event_queue/core/errors.py` which defines `EventQueueError` and specific errors: `MessageTypeError`, `ProducerNotStartedError`, `ProducerConfigError`, `ConsumerNotStartedError`, `ConsumerConfigError`, and `ConsumerFetchError`.
- Updated `components/bot_detector/event_queue/adapters/kafka/adapter.py` to import and return/raise the new typed errors, and to use `MessageTypeError` instead of generic exceptions for invalid payload types, and `ConsumerFetchError`/`ProducerConfigError`/`ProducerNotStartedError` where appropriate.
- Expanded `test/components/bot_detector/event_queue/test_adapter_kafka.py` with many new tests to cover producer/consumer no-op starts/stops, producer partition key byte/string/invalid branches, validation error handling, `get_many` timeout and empty-record handling, commit behavior, and `AIOKafkaAdapter` delegation and disabled-side guards; tests import `Batcher` and assert `ValidationError` where relevant.

### Testing
- Ran `pytest test/components/bot_detector/event_queue/test_adapter_kafka.py`, which failed during collection with `ModuleNotFoundError: No module named 'orjson'` due to a missing test dependency; no tests were executed to completion.
- Test additions and adapter changes were committed so CI or a developer environment with required dependencies (notably `orjson`) can run the expanded test suite with `pytest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984700970e083259497e8554f3061f8)