### PR TITLE
Add in-memory event queue adapter tests

### DIFF
--- a/components/bot_detector/event_queue/adapters/memory/adapter.py
+++ b/components/bot_detector/event_queue/adapters/memory/adapter.py
@@ -66,7 +66,7 @@ class InMemoryProducerAdapter(_InMemoryBase[T], QueueBackendProducerProtocol):
             await self._queue.put(message)
 
 
-class InMemoryAdapter(Generic[T], QueueBackendProtocol):
+class InMemoryAdapter(QueueBackendProtocol[T]):
     def __init__(
         self,
         cls: Type[T],

--- a/test/components/bot_detector/event_queue/adapter_memory/test_consumer_adapter.py
+++ b/test/components/bot_detector/event_queue/adapter_memory/test_consumer_adapter.py
@@ -1,0 +1,74 @@
+import pytest
+from bot_detector.event_queue.adapters.memory import (
+    InMemoryConfig,
+    InMemoryConsumerAdapter,
+)
+from pydantic import BaseModel
+
+
+class PlayerScraped(BaseModel):
+    id: int
+    username: str
+    score: int
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_one_empty():
+    config = InMemoryConfig(maxsize=10)
+    adapter = InMemoryConsumerAdapter(PlayerScraped, config)
+
+    result = await adapter.get_one()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_one_invalid_message():
+    config = InMemoryConfig(maxsize=10)
+    adapter = InMemoryConsumerAdapter(PlayerScraped, config)
+
+    adapter._queue.put_nowait({"id": 1})
+
+    result = await adapter.get_one()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_many_filters_invalid():
+    config = InMemoryConfig(maxsize=10)
+    adapter = InMemoryConsumerAdapter(PlayerScraped, config)
+
+    adapter._queue.put_nowait({"id": 1, "username": "Alice", "score": 100})
+    adapter._queue.put_nowait({"id": 2})
+    adapter._queue.put_nowait({"id": 3, "username": "Bob", "score": 200})
+
+    result = await adapter.get_many(3)
+
+    assert [item.username for item in result] == ["Alice", "Bob"]
+
+
+@pytest.mark.asyncio
+async def test_consumer_get_many_stops_on_empty():
+    config = InMemoryConfig(maxsize=10)
+    adapter = InMemoryConsumerAdapter(PlayerScraped, config)
+
+    adapter._queue.put_nowait({"id": 1, "username": "Alice", "score": 100})
+
+    result = await adapter.get_many(2)
+
+    assert [item.username for item in result] == ["Alice"]
+
+
+@pytest.mark.asyncio
+async def test_consumer_commit_after_get():
+    config = InMemoryConfig(maxsize=10)
+    adapter = InMemoryConsumerAdapter(PlayerScraped, config)
+
+    adapter._queue.put_nowait({"id": 1, "username": "Alice", "score": 100})
+
+    await adapter.get_one()
+
+    result = await adapter.commit()
+
+    assert result is None

--- a/test/components/bot_detector/event_queue/adapter_memory/test_producer_adapter.py
+++ b/test/components/bot_detector/event_queue/adapter_memory/test_producer_adapter.py
@@ -1,0 +1,23 @@
+import pytest
+from bot_detector.event_queue.adapters.memory import (
+    InMemoryConfig,
+    InMemoryProducerAdapter,
+)
+from pydantic import BaseModel
+
+
+class PlayerScraped(BaseModel):
+    id: int
+    username: str
+    score: int
+
+
+@pytest.mark.asyncio
+async def test_producer_put_enqueues_messages():
+    config = InMemoryConfig(maxsize=10)
+    adapter = InMemoryProducerAdapter(PlayerScraped, config)
+
+    await adapter.put([PlayerScraped(id=1, username="Alice", score=100)])
+
+    queued = adapter._queue.get_nowait()
+    assert queued == PlayerScraped(id=1, username="Alice", score=100)

--- a/test/components/bot_detector/event_queue/adapter_memory/test_queue_adapter.py
+++ b/test/components/bot_detector/event_queue/adapter_memory/test_queue_adapter.py
@@ -1,0 +1,31 @@
+import pytest
+from bot_detector.event_queue.adapters.memory import InMemoryAdapter, InMemoryConfig
+from pydantic import BaseModel
+
+
+class PlayerScraped(BaseModel):
+    id: int
+    username: str
+    score: int
+
+
+@pytest.mark.asyncio
+async def test_queue_adapter_wiring():
+    adapter = InMemoryAdapter(PlayerScraped, InMemoryConfig(maxsize=10))
+
+    await adapter.start()
+
+    await adapter.put(
+        [
+            PlayerScraped(id=1, username="Alice", score=100),
+            PlayerScraped(id=2, username="Bob", score=200),
+        ]
+    )
+
+    one = await adapter.get_one()
+    many = await adapter.get_many(2)
+    await adapter.commit()
+    await adapter.stop()
+
+    assert one == PlayerScraped(id=1, username="Alice", score=100)
+    assert [item.username for item in many] == ["Bob"]


### PR DESCRIPTION
### Motivation
- Provide test coverage for the in-memory event queue backend to match the existing Kafka adapter tests and ensure parity of behavior.
- Validate core consumer/producer behaviors such as validation filtering, enqueue/dequeue semantics, commit handling, and adapter wiring.

### Description
- Added three test files under `test/components/bot_detector/event_queue/adapter_memory/`: `test_consumer_adapter.py`, `test_producer_adapter.py`, and `test_queue_adapter.py` that mirror Kafka adapter test patterns.
- `test_consumer_adapter.py` verifies empty reads, validation failure filtering, batch collection stopping on empty queue, and `commit()` behavior using `InMemoryConsumerAdapter` and `InMemoryConfig`.
- `test_producer_adapter.py` verifies that `InMemoryProducerAdapter.put()` enqueues messages correctly.
- `test_queue_adapter.py` provides an end-to-end wiring test for `InMemoryAdapter` exercising `start()`, `put()`, `get_one()`, `get_many()`, `commit()`, and `stop()`.

### Testing
- Ran `uv run pytest test/components/bot_detector/event_queue/adapter_memory` to execute the new test suite; the run failed due to a dependency download error for `orjson==3.11.5` (network/tunnel error) so tests could not be executed in this environment.
- Test files were validated syntactically and added to the repository; no unit test failures from local static checks were observed prior to the blocked dependency resolution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848ad11ff8832582082baeefedc21f)