### PR TITLE
Handle queue put/get_many migration edge-cases in bases

### DIFF
--- a/bases/bot_detector/api_public/src/api/v2/report.py
+++ b/bases/bot_detector/api_public/src/api/v2/report.py
@@ -1,5 +1,5 @@
 from bot_detector.api_public.src.app.repositories.player import Player
-from bot_detector.api_public.src.app.repositories.report import CustomError, Report
+from bot_detector.api_public.src.app.repositories.report import Report
 from bot_detector.api_public.src.app.views.response.ok import Ok
 from bot_detector.api_public.src.core._cache import SimpleALRUCache
 from bot_detector.api_public.src.core.fastapi.dependencies.kafka import (
@@ -90,9 +90,20 @@ async def post_reports(
         _data.append(ParsedDetection(**_d))
 
     # print(_data)
-    try:
-        await report_repo.send_to_kafka(data=_data, producer=report_producer)
-    except CustomError:
+    produce_errors = await report_repo.send_to_kafka(
+        data=_data,
+        producer=report_producer,
+    )
+    if produce_errors:
+        wide_event.add_context(
+            {
+                "report": {
+                    "status": "error",
+                    "detail": str(produce_errors[0]),
+                    "produce_errors": len(produce_errors),
+                }
+            }
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal error",

--- a/bases/bot_detector/api_public/src/app/repositories/report.py
+++ b/bases/bot_detector/api_public/src/app/repositories/report.py
@@ -100,22 +100,19 @@ class Report:
         self,
         data: list[ParsedDetection],
         producer: QueueProducer[ReportsToInsertStruct],
-    ) -> None:
+    ) -> list[Exception]:
         tasks = []
 
         # Transform data to ReportsToInsertStruct
         reports, error = self._transform_detection(data)
 
         tasks = [producer.put([report]) for report in reports]
-        produce_results = await asyncio.gather(*tasks)
+        produce_results = await asyncio.gather(*tasks, return_exceptions=True)
         produce_errors = [
             result for result in produce_results if isinstance(result, Exception)
         ]
-        if produce_errors:
-            raise CustomError(f"Failed to send reports to kafka: {produce_errors[0]}")
 
         if len(error) > 0:
-            error_msg = f"Received {len(error)} validation errors like this: {error[0]}"
             wide_event.add_context(
                 {
                     "report": {
@@ -124,4 +121,10 @@ class Report:
                     }
                 }
             )
-            raise CustomError(error_msg)
+            produce_errors.append(
+                CustomError(
+                    f"Received {len(error)} validation errors like this: {error[0]}"
+                )
+            )
+
+        return produce_errors

--- a/bases/bot_detector/api_public/src/app/repositories/report.py
+++ b/bases/bot_detector/api_public/src/app/repositories/report.py
@@ -106,8 +106,13 @@ class Report:
         # Transform data to ReportsToInsertStruct
         reports, error = self._transform_detection(data)
 
-        tasks = [producer.produce_one(report) for report in reports]
-        await asyncio.gather(*tasks)
+        tasks = [producer.put([report]) for report in reports]
+        produce_results = await asyncio.gather(*tasks)
+        produce_errors = [
+            result for result in produce_results if isinstance(result, Exception)
+        ]
+        if produce_errors:
+            raise CustomError(f"Failed to send reports to kafka: {produce_errors[0]}")
 
         if len(error) > 0:
             error_msg = f"Received {len(error)} validation errors like this: {error[0]}"

--- a/bases/bot_detector/hiscore_scraper/core.py
+++ b/bases/bot_detector/hiscore_scraper/core.py
@@ -76,22 +76,34 @@ async def scrape_player(
         not_found_counter.labels(proxy=proxy).inc()
         logger.debug(f"[{worker_id}][{player.name}]: not found.")
         player.possible_ban = True
-        await player_nf_producer.produce_one(
-            NotFoundStruct(
-                metadata=MetaData(version=1, source="hiscore_scraper"),
-                player_data=player,
-            )
+        produce_error = await player_nf_producer.put(
+            [
+                NotFoundStruct(
+                    metadata=MetaData(version=1, source="hiscore_scraper"),
+                    player_data=player,
+                )
+            ]
         )
+        if produce_error:
+            logger.error(
+                f"[{worker_id}][{player.name}]: Failed to publish not_found: {produce_error}"
+            )
         return None, False
     except UnexpectedRedirection as e:
         error_counter.labels(proxy=proxy).inc()
         logger.warning(f"[{worker_id}][{player.name}]: {e=}")
-        await player_ts_producer.produce_one(
-            ToScrapeStruct(
-                metadata=MetaData(version=1, source="hiscore_scraper"),
-                player_data=player,
-            )
+        produce_error = await player_ts_producer.put(
+            [
+                ToScrapeStruct(
+                    metadata=MetaData(version=1, source="hiscore_scraper"),
+                    player_data=player,
+                )
+            ]
         )
+        if produce_error:
+            logger.error(
+                f"[{worker_id}][{player.name}]: Failed to requeue scrape: {produce_error}"
+            )
         return None, True
     except (
         aiohttp.ClientResponseError,
@@ -102,12 +114,18 @@ async def scrape_player(
     ) as e:
         error_counter.labels(proxy=proxy).inc()
         logger.warning(f"[{worker_id}][{player.name}]: {e=}")
-        await player_ts_producer.produce_one(
-            ToScrapeStruct(
-                metadata=MetaData(version=1, source="hiscore_scraper"),
-                player_data=player,
-            )
+        produce_error = await player_ts_producer.put(
+            [
+                ToScrapeStruct(
+                    metadata=MetaData(version=1, source="hiscore_scraper"),
+                    player_data=player,
+                )
+            ]
         )
+        if produce_error:
+            logger.error(
+                f"[{worker_id}][{player.name}]: Failed to requeue scrape: {produce_error}"
+            )
         return None, True
 
 
@@ -140,12 +158,18 @@ async def transform_player_stats(
     except ValidationError as e:
         error = e.json()
         logger.error(error)
-        await player_ts_producer.produce_one(
-            ToScrapeStruct(
-                metadata=MetaData(version=1, source="hiscore_scraper"),
-                player_data=player,
-            )
+        produce_error = await player_ts_producer.put(
+            [
+                ToScrapeStruct(
+                    metadata=MetaData(version=1, source="hiscore_scraper"),
+                    player_data=player,
+                )
+            ]
         )
+        if produce_error:
+            logger.error(
+                f"Failed to requeue player after transform failure: {produce_error}"
+            )
         return None
 
 
@@ -276,11 +300,12 @@ async def work(
             # Successful scrape - reset retry counter
             retry_tracker.record_attempt(worker_id, success=True)
 
-            partition_key = str(scraped_data.player_data.id % 10).encode("utf-8")
-            await player_sc_producer.produce_one(
-                message=scraped_data,
-                partition_key=partition_key,
-            )
+            produce_error = await player_sc_producer.put([scraped_data])
+            if produce_error:
+                logger.error(
+                    f"[{worker_id}][{player_data.name}]: Failed to publish scraped data: {produce_error}"
+                )
+                continue
             logger.debug(f"[{worker_id}][{player_data.name}]: scraped successfully.")
 
 

--- a/bases/bot_detector/runemetrics_scraper/core.py
+++ b/bases/bot_detector/runemetrics_scraper/core.py
@@ -207,7 +207,11 @@ async def work(
             if error:
                 error_counter.labels(proxy=_proxy).inc()
                 logger.warning(f"[{worker_id}][{player_data.name}]: {error=}")
-                await player_nf_queue.produce_one(player)
+                produce_error = await player_nf_queue.put([player])
+                if produce_error:
+                    logger.error(
+                        f"[{worker_id}]: Failed to requeue player: {produce_error}"
+                    )
                 await asyncio.sleep(10)
                 continue
 
@@ -226,15 +230,21 @@ async def work(
             except ValidationError as e:
                 error = e.json()
                 logger.error(error)
-                await player_nf_queue.produce_one(player)
+                produce_error = await player_nf_queue.put([player])
+                if produce_error:
+                    logger.error(
+                        f"[{worker_id}]: Failed to requeue player: {produce_error}"
+                    )
                 continue
 
             # push data to kafka
             success_counter.labels(proxy=_proxy).inc()
-            await player_sc_producer.produce_one(
-                scraped_data,
-                partition_key=str(scraped_data.player_data.id % 10).encode("utf-8"),
-            )
+            produce_error = await player_sc_producer.put([scraped_data])
+            if produce_error:
+                logger.error(
+                    f"[{worker_id}]: Failed to produce scraped player: {produce_error}"
+                )
+                continue
             logger.debug(
                 f"[{worker_id}][{player_data.name}]: {player_data.label_jagex=}"
             )

--- a/bases/bot_detector/worker_hiscore/core.py
+++ b/bases/bot_detector/worker_hiscore/core.py
@@ -118,8 +118,13 @@ async def produce_data_to_predict(
         _data_to_predict = transform_scraped_struct(_record)
         if _data_to_predict is None:
             continue
-        _tasks.append(data_to_predict_producer.produce_one(message=_data_to_predict))
-    await asyncio.gather(*_tasks)
+        _tasks.append(data_to_predict_producer.put([_data_to_predict]))
+
+    produce_results = await asyncio.gather(*_tasks)
+    for produce_result in produce_results:
+        if isinstance(produce_result, Exception):
+            logger.error(f"Failed to produce data_to_predict message: {produce_result}")
+
     logger.info(f"Produced {len(_tasks)} messages to data to predict topic.")
 
 
@@ -134,16 +139,18 @@ async def consume_many_task(
     session_factory: async_sessionmaker[AsyncSession],
 ):
     while True:
-        batch = []
+        batch: list[ScrapedStruct] = []
         try:
-            batch, errors = await player_sc_queue.consume_many(
-                max_records=max_messages,
-                timeout_ms=max_interval_ms,
-            )
-            logger.info(f"[{worker_id}] consumed {len(batch)} scrapes")
+            consume_result = await player_sc_queue.get_many(count=max_messages)
+            if isinstance(consume_result, Exception):
+                logger.error(
+                    f"[{worker_id}] Error during consumption: {consume_result}"
+                )
+                await asyncio.sleep(15)
+                continue
 
-            if errors:
-                logger.error(f"[{worker_id}] Errors during consumption: {errors}")
+            batch = consume_result
+            logger.info(f"[{worker_id}] consumed {len(batch)} scrapes")
 
             if not batch:
                 logger.info("No highscore data to process.")
@@ -164,14 +171,14 @@ async def consume_many_task(
 
             if error:
                 logger.error(f"{error}")
-                await asyncio.gather(
-                    *[
-                        player_sc_queue.produce_one(
-                            b, partition_key=str(b.player_data.id % 10).encode("utf-8")
-                        )
-                        for b in batch
-                    ]
+                requeue_results = await asyncio.gather(
+                    *[player_sc_queue.put([b]) for b in batch]
                 )
+                for requeue_result in requeue_results:
+                    if isinstance(requeue_result, Exception):
+                        logger.error(
+                            f"Failed to requeue scraped message: {requeue_result}"
+                        )
                 await asyncio.sleep(15)
 
             await player_sc_queue.commit()
@@ -183,14 +190,14 @@ async def consume_many_task(
             logger.error(f"[{worker_id}] Error consuming scrapes: {e}")
             logger.debug(f"[{worker_id}] Traceback: \n{traceback.format_exc()}")
             if batch:  # only retry if we have data
-                await asyncio.gather(
-                    *[
-                        player_sc_queue.produce_one(
-                            b, partition_key=str(b.player_data.id % 10).encode("utf-8")
-                        )
-                        for b in batch
-                    ]
+                requeue_results = await asyncio.gather(
+                    *[player_sc_queue.put([b]) for b in batch]
                 )
+                for requeue_result in requeue_results:
+                    if isinstance(requeue_result, Exception):
+                        logger.error(
+                            f"Failed to requeue scraped message: {requeue_result}"
+                        )
             await asyncio.sleep(15)
 
 


### PR DESCRIPTION
### Motivation
- Align base code with the migrated queue API (`put(...)` / `get_many(...)`) and ensure producer failures are not silently ignored. 
- Avoid runtime issues caused by iterating or committing on a possible `Exception` return from `get_many(...)` by narrowing the result first. 
- Surface enqueue/requeue failures as logs or errors so operational issues are visible and recoverable.

### Description
- Updated base producers to await `put([...])` and inspect the return value, logging any `Exception` returned instead of ignoring it in `runemetrics_scraper`, `hiscore_scraper`, and `worker_hiscore`.
- Replaced legacy consumer usages with `get_many(count=...)` patterns in `worker_hiscore` and introduced an intermediate `consume_result` variable to detect `Exception` return values before assigning to `batch`.
- Converted requeue paths to use `put([...])` and gather individual results, logging any failures found in the gathered results.
- Changed the API `report` repository to collect `producer.put([report])` results and raise `CustomError` if any produce call returned an `Exception`.

### Testing
- Ran formatting checks with `uv run ruff format --check .` and fixed formatting where required, which passed. 
- Ran linter checks with `uv run ruff check` for the modified files, and the checks passed for those files. 
- Ran `uv run pyright` on the modified modules, which still reports pre-existing typing issues unrelated to this patch and therefore the typecheck run did not fully succeed for the workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979e8911d08325be4f9c890f98b64b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored message queuing to use batch processing operations for improved efficiency
  * Enhanced error handling and logging across data processing workflows to improve troubleshooting and system visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->