### PR TITLE
Normalize QueueFactory Kafka bootstrap server setting usage

### DIFF
--- a/bases/bot_detector/hiscore_scraper/core.py
+++ b/bases/bot_detector/hiscore_scraper/core.py
@@ -314,7 +314,7 @@ async def main():
     proxies = await proxy_manager.fetch_proxies()
 
     # initialize kafka producers and consumers
-    b_server = KafkaSettings().KAFKA_BOOTSTRAP_SERVERS
+    b_server = KafkaSettings().bootstrap_servers
     player_ts_queue = QueueFactory.create_queue(
         model=ToScrapeStruct,
         queue_type="queue",

--- a/bases/bot_detector/job_hs_migration_v3/core.py
+++ b/bases/bot_detector/job_hs_migration_v3/core.py
@@ -185,7 +185,7 @@ async def producer_send(
 
 async def main():
     async_session, async_engine = get_session_factory(SETTINGS=DBSettings())
-    b_server = KafkaSettings().KAFKA_BOOTSTRAP_SERVERS
+    b_server = KafkaSettings().bootstrap_servers
     queue = QueueFactory.create_queue(
         model=ScrapedStruct,
         queue_type="producer",

--- a/bases/bot_detector/runemetrics_scraper/core.py
+++ b/bases/bot_detector/runemetrics_scraper/core.py
@@ -255,7 +255,7 @@ async def main():
     proxies = await proxy_manager.fetch_proxies()
 
     # initialize kafka producers and consumers
-    b_server = KafkaSettings().KAFKA_BOOTSTRAP_SERVERS
+    b_server = KafkaSettings().bootstrap_servers
 
     player_nf_queue = QueueFactory.create_queue(
         model=NotFoundStruct,

--- a/bases/bot_detector/scrape_task_producer/core.py
+++ b/bases/bot_detector/scrape_task_producer/core.py
@@ -257,7 +257,7 @@ async def process_players(
 async def main():
     async_session, async_engine = get_session_factory(SETTINGS=DBSettings())
 
-    bootstrap_servers = KafkaSettings().KAFKA_BOOTSTRAP_SERVERS
+    bootstrap_servers = KafkaSettings().bootstrap_servers
     queue = QueueFactory.create_queue(
         model=ToScrapeStruct,
         queue_type="queue",

--- a/bases/bot_detector/worker_hiscore/core.py
+++ b/bases/bot_detector/worker_hiscore/core.py
@@ -214,7 +214,7 @@ async def main():
         backend_type="kafka",
         config=KafkaConfig(
             topic="players.scraped",
-            bootstrap_servers=KafkaSettings().KAFKA_BOOTSTRAP_SERVERS,
+            bootstrap_servers=KafkaSettings().bootstrap_servers,
             producer=True,
             consumer=True,
             producer_config=KafkaProducerConfig(
@@ -229,7 +229,7 @@ async def main():
         backend_type="kafka",
         config=KafkaConfig(
             topic="data.to_predict",
-            bootstrap_servers=KafkaSettings().KAFKA_BOOTSTRAP_SERVERS,
+            bootstrap_servers=KafkaSettings().bootstrap_servers,
             producer=True,
             producer_config=KafkaProducerConfig(partition_key_fn=None),
         ),


### PR DESCRIPTION
### Motivation
- Ensure all Kafka bootstrap server references in base queue construction sites use the consolidated `KafkaSettings().bootstrap_servers` attribute instead of the legacy `KAFKA_BOOTSTRAP_SERVERS` constant.
- Keep queue and topic configuration unchanged while making the bootstrap server source uniform across bases.

### Description
- Replaced `KafkaSettings().KAFKA_BOOTSTRAP_SERVERS` with `KafkaSettings().bootstrap_servers` in the following base files: `bases/bot_detector/scrape_task_producer/core.py`, `bases/bot_detector/worker_hiscore/core.py`, `bases/bot_detector/runemetrics_scraper/core.py`, `bases/bot_detector/job_hs_migration_v3/core.py`, and `bases/bot_detector/hiscore_scraper/core.py`.
- Preserved existing `KafkaConfig(...)` topic/producer/consumer settings and only changed the bootstrap server attribute reads.
- Ensured all `KafkaConfig(bootstrap_servers=...)` usages in the updated scopes are now sourced from `KafkaSettings().bootstrap_servers` (either directly or via a local `b_server`/`bootstrap_servers` variable).

### Testing
- Ran `rg -n "KAFKA_BOOTSTRAP_SERVERS" bases/bot_detector/**/core.py` and confirmed there are no remaining matches (success).
- Verified `rg -n "bootstrap_servers\s*=" bases/bot_detector/**/core.py` to check the updated `KafkaConfig` assignments and confirm they reference `KafkaSettings().bootstrap_servers` or the local variable (success).
- Ran `uv run ruff format --check .` to validate formatting rules and it passed (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a0a1692e48325ad5985a2b38c0879)