### PR TITLE
Use `get_one()` contract in hiscore and runemetrics scraper queues

### DIFF
--- a/bases/bot_detector/hiscore_scraper/core.py
+++ b/bases/bot_detector/hiscore_scraper/core.py
@@ -220,14 +220,14 @@ async def get_player_to_scrape(
     worker_id: int,
     player_ts_queue: Queue[ToScrapeStruct],
 ) -> ToScrapeStruct | None:
-    player_to_scrape, error = await player_ts_queue.consume_one()
-    if error:
-        logger.error(f"[{worker_id}]: Error consuming player to scrape: {error}")
+    result = await player_ts_queue.get_one()
+    if isinstance(result, Exception):
+        logger.error(f"[{worker_id}]: Error consuming player to scrape: {result}")
         return None
-    if player_to_scrape is None:
+    if result is None:
         logger.warning(f"[{worker_id}]: No player available.")
         return None
-    return player_to_scrape
+    return result
 
 
 async def work(

--- a/bases/bot_detector/runemetrics_scraper/core.py
+++ b/bases/bot_detector/runemetrics_scraper/core.py
@@ -168,21 +168,18 @@ async def work(
                 continue
 
             # get player from kafka
-            try:
-                player, error = await player_nf_queue.consume_one()
-            except ValidationError as e:
-                error = e.json()
-                logger.error(error)
-                continue
-            if error:
-                logger.error(f"[{worker_id}]: {error}")
+            result = await player_nf_queue.get_one()
+            if isinstance(result, Exception):
+                logger.error(f"[{worker_id}]: {result}")
                 await asyncio.sleep(10)
                 continue
 
-            if player is None:
+            if result is None:
                 logger.error(f"[{worker_id}]: No player available.")
                 await asyncio.sleep(10)
                 continue
+
+            player = result
 
             player_data = player.player_data
 


### PR DESCRIPTION
### Motivation
- The queue interface was changed to return `Optional[T] | Exception` via `get_one()` instead of the `(value, error)` tuple from `consume_one()`, so scrapers must be updated to the new contract.

### Description
- Replaced `await ...consume_one()` with `await ...get_one()` in `bases/bot_detector/hiscore_scraper/core.py` and `bases/bot_detector/runemetrics_scraper/core.py`.
- Refactored control flow to branch on the `get_one()` contract: treat `Exception` results as logged errors with a retry/sleep path, treat `None` as an empty queue, and otherwise treat the returned value as the typed payload.
- Removed tuple unpacking and updated local variables to use a single `result` value and then narrow to the payload (e.g. `player = result`).

### Testing
- Ran `uv run ruff format --check bases/bot_detector/hiscore_scraper/core.py bases/bot_detector/runemetrics_scraper/core.py` which passed.
- Ran `uv run ruff check bases/bot_detector/hiscore_scraper/core.py bases/bot_detector/runemetrics_scraper/core.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a0a6b1854832589465491120a6b88)