### PR TITLE
Assert producer is QueueProducer and add exception guard in hiscore worker

### DIFF
--- a/bases/bot_detector/worker_hiscore/core.py
+++ b/bases/bot_detector/worker_hiscore/core.py
@@ -236,7 +236,9 @@ async def main():
             producer_config=KafkaProducerConfig(partition_key_fn=None),
         ),
     )
-    assert isinstance(data_to_predict_producer, Queue)
+    if isinstance(data_to_predict_producer, Exception):
+        raise data_to_predict_producer
+    assert isinstance(data_to_predict_producer, QueueProducer)
 
     await player_sc_queue.start()
     await data_to_predict_producer.start()


### PR DESCRIPTION
### Motivation
- Ensure the `data_to_predict_producer` value returned from `QueueFactory.create_queue` is properly narrowed to the producer-only type and surface any creation errors immediately.

### Description
- Added an explicit exception guard after `QueueFactory.create_queue(...)` for `data_to_predict_producer` to raise any `Exception` result instead of letting it flow silently into runtime usage.
- Replaced the runtime assertion `assert isinstance(data_to_predict_producer, Queue)` with `assert isinstance(data_to_predict_producer, QueueProducer)` to reflect the producer-only queue type and enable accurate typing.
- `QueueProducer` is already imported from `bot_detector.event_queue.core`, so no import changes were needed.

### Testing
- Ran type checking with `uv run mypy bases/bot_detector/worker_hiscore/core.py`, which reported import-untyped errors due to local package stubs; this is an environment limitation and not a regression in the change.
- Ran `uv run mypy --disable-error-code import-untyped bases/bot_detector/worker_hiscore/core.py`, which completed successfully with no issues.
- Ran `uv run ruff format --check bases/bot_detector/worker_hiscore/core.py`, which reported the file is already formatted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a11464a9483258ea2bf32b71df2e3)