### PR TITLE
Add explicit queue type assertions in runemetrics scraper startup

### DIFF
--- a/bases/bot_detector/runemetrics_scraper/core.py
+++ b/bases/bot_detector/runemetrics_scraper/core.py
@@ -284,6 +284,9 @@ async def main():
         if isinstance(queue, Exception):
             raise queue
 
+    assert isinstance(player_nf_queue, Queue)
+    assert isinstance(player_sc_producer, QueueProducer)
+
     await player_nf_queue.start()
     await player_sc_producer.start()
 


### PR DESCRIPTION
### Motivation
- Ensure the runtime types of the queues produced by `QueueFactory.create_queue` are the expected queue abstractions before starting them and wiring them into workers to catch misconfigurations early.

### Description
- Added explicit runtime assertions immediately after the existing `Exception` checks in `main()`: `assert isinstance(player_nf_queue, Queue)` and `assert isinstance(player_sc_producer, QueueProducer)`, placing them before the `start()` calls and before these objects are passed into `work(...)`, and kept the existing `Exception` handling; the file already imports `Queue` and `QueueProducer` from `bot_detector.event_queue.core`.

### Testing
- Ran formatting check with `uv run ruff format --check .`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a11625d6483258a385ca61ad6e6f3)