### PR TITLE
Add explicit queue assertions in hiscore scraper main setup

### DIFF
--- a/bases/bot_detector/hiscore_scraper/core.py
+++ b/bases/bot_detector/hiscore_scraper/core.py
@@ -356,6 +356,10 @@ async def main():
         if isinstance(queue, Exception):
             raise queue
 
+    assert isinstance(player_ts_queue, Queue)
+    assert isinstance(player_nf_producer, QueueProducer)
+    assert isinstance(player_sc_producer, QueueProducer)
+
     await player_ts_queue.start()
     await player_nf_producer.start()
     await player_sc_producer.start()


### PR DESCRIPTION
### Motivation
- Ensure runtime safety by validating that queue factory outputs are the expected runtime types before starting or using them.

### Description
- Kept the existing `Exception` validation loop and added explicit asserts immediately after it: `assert isinstance(player_ts_queue, Queue)`, `assert isinstance(player_nf_producer, QueueProducer)`, and `assert isinstance(player_sc_producer, QueueProducer)`, placed before any `start()` calls and before worker task construction, and relied on the already-present `Queue` and `QueueProducer` imports.

### Testing
- Ran `uv run ruff format --check .` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a116de4d08325ba51b3c6a27277e3)