### PR TITLE
Add explicit QueueProducer narrowing in hs migration job

### DIFF
--- a/bases/bot_detector/job_hs_migration_v3/core.py
+++ b/bases/bot_detector/job_hs_migration_v3/core.py
@@ -20,6 +20,7 @@ from bot_detector.structs import (
     MetaData,
     PlayerStruct,
 )
+from pydantic import BaseModel
 from pydantic_settings import BaseSettings
 from sqlalchemy import TextClause
 from sqlalchemy.exc import OperationalError
@@ -186,6 +187,11 @@ async def producer_send(
 async def main():
     async_session, async_engine = get_session_factory(SETTINGS=DBSettings())
     b_server = KafkaSettings().bootstrap_servers
+
+    def partition_key_fn(message: BaseModel) -> str:
+        assert isinstance(message, ScrapedStruct)
+        return str(message.player_data.id % 10)
+
     queue = QueueFactory.create_queue(
         model=ScrapedStruct,
         queue_type="producer",
@@ -194,13 +200,12 @@ async def main():
             topic="players.scraped",
             bootstrap_servers=b_server,
             producer=True,
-            producer_config=KafkaProducerConfig(
-                partition_key_fn=lambda message: str(message.player_data.id % 10)
-            ),
+            producer_config=KafkaProducerConfig(partition_key_fn=partition_key_fn),
         ),
     )
     if isinstance(queue, Exception):
         raise queue
+    assert isinstance(queue, QueueProducer)
     player_sc_producer = queue
     produce_queue = asyncio.Queue(maxsize=1)
     stop_event = asyncio.Event()


### PR DESCRIPTION
### Motivation
- Ensure the highscore migration job has explicit static type guarantees for the queue producer so calls like `start()`, `stop()`, and `put()` are type-safe under Pyright and to avoid attribute-access errors on generic `BaseModel` types.

### Description
- Inserted `assert isinstance(queue, QueueProducer)` immediately after the existing `Exception` guard and kept `player_sc_producer = queue` to preserve runtime flow.
- Confirmed `QueueProducer` is imported from `bot_detector.event_queue.core` and used as the narrowed type for the queue variable.
- Replaced the inline Kafka partition lambda with a typed helper `partition_key_fn(message: BaseModel) -> str` that asserts `isinstance(message, ScrapedStruct)` before accessing `message.player_data.id` to satisfy static checking.
- Added a small import of `BaseModel` from `pydantic` to support the typed partition function and formatted the file with `ruff`.

### Testing
- Ran `uv run ruff format --check bases/bot_detector/job_hs_migration_v3/core.py` which passed after running `uv run ruff format` to reformat the file. (succeeded)
- Ran `uv run pyright bases/bot_detector/job_hs_migration_v3/core.py` and confirmed there are `0 errors, 0 warnings, 0 informations` from Pyright. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a117db91c8325947f2bbd938f8b96)