### PR TITLE
Assert Queue type after create_queue in scrape_task_producer.main

### DIFF
--- a/bases/bot_detector/scrape_task_producer/core.py
+++ b/bases/bot_detector/scrape_task_producer/core.py
@@ -275,6 +275,7 @@ async def main():
     )
     if isinstance(queue, Exception):
         raise queue
+    assert isinstance(queue, Queue)
     player_queue = queue
 
     await player_queue.start()


### PR DESCRIPTION
### Motivation
- Narrow the runtime type of `queue` returned by `QueueFactory.create_queue(...)` so subsequent calls that expect a `Queue[...]` (like `start()`, `stop()`, and `process_players(...)`) are protected and unexpected types surface early.

### Description
- Keep the existing `if isinstance(queue, Exception): raise queue` guard and add `assert isinstance(queue, Queue)` immediately afterwards before assigning `player_queue = queue`, while retaining the `Queue` import from `bot_detector.event_queue.core`.

### Testing
- Ran `uv run ruff format --check .` which succeeded (output: "229 files already formatted").
- Ran `uv run mypy bases/bot_detector/scrape_task_producer/core.py` which reported `import-untyped` errors for local packages in this environment and thus did not fully succeed, but these errors are unrelated to the added runtime `assert`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1182eca883258553e47759db36ef)