### PR TITLE
Add QueueProducer type assertion in API lifespan

### DIFF
--- a/bases/bot_detector/api_public/src/core/server.py
+++ b/bases/bot_detector/api_public/src/core/server.py
@@ -11,6 +11,7 @@ from bot_detector.event_queue.adapters.kafka import (
     KafkaProducerConfig,
     KafkaSettings,
 )
+from bot_detector.event_queue.core import QueueProducer
 from bot_detector.event_queue.factory import QueueFactory
 from bot_detector.event_queue.structs import ReportsToInsertStruct
 from fastapi import FastAPI
@@ -61,6 +62,7 @@ async def lifespan(app: FastAPI):
     )
     if isinstance(queue, Exception):
         raise queue
+    assert isinstance(queue, QueueProducer)
     app.state.reports_to_insert_producer = queue
     producer = app.state.reports_to_insert_producer
     await producer.start()


### PR DESCRIPTION
### Motivation
- Ensure the object returned by `QueueFactory.create_queue` is the expected producer type before assigning it to `app.state` to catch unexpected factory errors early.

### Description
- Import `QueueProducer` from `bot_detector.event_queue.core` in `bases/bot_detector/api_public/src/core/server.py` and add `assert isinstance(queue, QueueProducer)` immediately after the existing `Exception` check and before assigning `queue` to `app.state.reports_to_insert_producer` while preserving the existing startup/shutdown lifecycle (`await producer.start()` before `yield`, `await producer.stop()` after).

### Testing
- Ran `uv run ruff format --check .` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1188fe0083258efeafa09e1f0f69)