### PR TITLE
Move lag probe implementations into backend adapter packages

### DIFF
--- a/bases/bot_detector/scrape_task_producer/core.py
+++ b/bases/bot_detector/scrape_task_producer/core.py
@@ -12,8 +12,9 @@ from bot_detector.event_queue.adapters.kafka import (
     KafkaProducerConfig,
 )
 from bot_detector.event_queue.core import Queue
-from bot_detector.event_queue.factory import QueueFactory
+from bot_detector.event_queue.factory import QueueFactory, create_lag_probe
 from bot_detector.event_queue.adapters.kafka import KafkaSettings
+from bot_detector.event_queue.lag_probe import LagProbeProtocol
 from bot_detector.event_queue.structs import ToScrapeStruct
 from bot_detector.structs import MetaData, PlayerStruct
 from bot_detector.wide_event import WideEventLogger
@@ -173,6 +174,9 @@ async def process_players(
     async_session: async_sessionmaker[AsyncSession],
     player_repo: PlayerRepo,
     player_queue: Queue[ToScrapeStruct],
+    lag_probe: LagProbeProtocol,
+    lag_topic: str,
+    lag_group_id: str,
     limit: int = 10,
 ):
     max_days = 20
@@ -188,7 +192,7 @@ async def process_players(
     while True:
         token = wide_event.set({})
         try:
-            lag = await player_queue.lag()
+            lag = await lag_probe.lag(topic=lag_topic, group_id=lag_group_id)
             if last_day != date.today():
                 wide_event.add({"new_day_reset": True})
                 _force_log()
@@ -258,19 +262,22 @@ async def main():
     async_session, async_engine = get_session_factory(SETTINGS=DBSettings())
 
     bootstrap_servers = KafkaSettings().bootstrap_servers
+    lag_topic = "players.to_scrape"
+    lag_group_id = "scraper"
+
     queue = QueueFactory.create_queue(
         model=ToScrapeStruct,
         queue_type="queue",
         backend_type="kafka",
         config=KafkaConfig(
-            topic="players.to_scrape",
+            topic=lag_topic,
             bootstrap_servers=bootstrap_servers,
             producer=True,
             consumer=True,
             producer_config=KafkaProducerConfig(
                 partition_key_fn=lambda message: str(message.player_data.id % 10)
             ),
-            consumer_config=KafkaConsumerConfig(group_id="scraper"),
+            consumer_config=KafkaConsumerConfig(group_id=lag_group_id),
         ),
     )
     if isinstance(queue, Exception):
@@ -278,17 +285,29 @@ async def main():
     assert isinstance(queue, Queue)
     player_queue = queue
 
+    lag_probe = create_lag_probe(
+        backend_type="kafka",
+        bootstrap_servers=bootstrap_servers,
+    )
+    if isinstance(lag_probe, Exception):
+        raise lag_probe
+
     await player_queue.start()
+    await lag_probe.start()
 
     try:
         await process_players(
             async_session=async_session,
             player_repo=PlayerRepo(),
             player_queue=player_queue,
+            lag_probe=lag_probe,
+            lag_topic=lag_topic,
+            lag_group_id=lag_group_id,
             limit=Settings().LIMIT,
         )
     finally:
         await async_engine.dispose()
+        await lag_probe.stop()
         await player_queue.stop()
 
 

--- a/components/bot_detector/event_queue/__init__.py
+++ b/components/bot_detector/event_queue/__init__.py
@@ -1,5 +1,6 @@
 from .adapters.kafka import KafkaSettings as Settings
-from .factory import QueueFactory
+from .factory import QueueFactory, create_lag_probe
+from .lag_probe import LagProbeProtocol
 from .structs import (
     DataToPredictStruct,
     HighScoreStruct,
@@ -11,6 +12,8 @@ from .structs import (
 
 __all__ = [
     "QueueFactory",
+    "create_lag_probe",
+    "LagProbeProtocol",
     "Settings",
     "ToScrapeStruct",
     "ScrapedStruct",

--- a/components/bot_detector/event_queue/adapters/kafka/__init__.py
+++ b/components/bot_detector/event_queue/adapters/kafka/__init__.py
@@ -1,5 +1,6 @@
 from .adapter import AIOKafkaAdapter, AIOKafkaConsumerAdapter, AIOKafkaProducerAdapter
 from .config import KafkaConfig, KafkaConsumerConfig, KafkaProducerConfig
+from .lag_adapter import KafkaLagProbe
 from .settings import Settings as KafkaSettings
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "KafkaConsumerConfig",
     "KafkaProducerConfig",
     "KafkaSettings",
+    "KafkaLagProbe",
 ]

--- a/components/bot_detector/event_queue/adapters/kafka/adapter.py
+++ b/components/bot_detector/event_queue/adapters/kafka/adapter.py
@@ -3,12 +3,7 @@ import logging
 from typing import Generic, Optional, TypeVar
 
 import orjson
-from aiokafka import (
-    AIOKafkaConsumer,
-    AIOKafkaProducer,
-    ConsumerRecord,
-    TopicPartition,
-)
+from aiokafka import AIOKafkaConsumer, AIOKafkaProducer, ConsumerRecord
 from aiokafka.errors import KafkaTimeoutError
 from bot_detector.event_queue.core.batcher import Batcher
 from bot_detector.event_queue.core.errors import (
@@ -204,21 +199,6 @@ class AIOKafkaConsumerAdapter(
             )
         await self.consumer.commit()
 
-    async def lag(self) -> int:
-        if self.consumer is None:
-            return 0
-        total_lag = 0
-        partitions = self.consumer.partitions_for_topic(self.config.topic)
-        if partitions is None:
-            return 0
-
-        for partition in partitions:
-            tp = TopicPartition(self.config.topic, partition)
-            committed = await self.consumer.committed(tp) or 0
-            end_offset = await self.consumer.end_offsets([tp])
-            total_lag += end_offset[tp] - committed
-        return total_lag
-
 
 class AIOKafkaAdapter(QueueBackendProtocol[T]):
     """
@@ -254,6 +234,3 @@ class AIOKafkaAdapter(QueueBackendProtocol[T]):
 
     async def commit(self) -> Optional[Exception]:
         await self.consumer.commit()
-
-    async def lag(self) -> int:
-        return await self.consumer.lag()

--- a/components/bot_detector/event_queue/adapters/kafka/lag_adapter.py
+++ b/components/bot_detector/event_queue/adapters/kafka/lag_adapter.py
@@ -1,0 +1,50 @@
+from aiokafka import AIOKafkaConsumer, TopicPartition
+
+from bot_detector.event_queue.lag_probe.interface import LagProbeProtocol
+
+
+class KafkaLagProbe(LagProbeProtocol):
+    def __init__(self, bootstrap_servers: str):
+        self.bootstrap_servers = bootstrap_servers
+        self._consumers: dict[str, AIOKafkaConsumer] = {}
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        for consumer in self._consumers.values():
+            await consumer.stop()
+        self._consumers.clear()
+
+    async def lag(self, topic: str, group_id: str) -> int:
+        consumer = await self._get_or_create_consumer(topic=topic, group_id=group_id)
+
+        partitions = consumer.partitions_for_topic(topic)
+        if partitions is None:
+            return 0
+
+        total_lag = 0
+        for partition in partitions:
+            tp = TopicPartition(topic, partition)
+            committed = await consumer.committed(tp) or 0
+            end_offsets = await consumer.end_offsets([tp])
+            total_lag += end_offsets[tp] - committed
+        return total_lag
+
+    async def _get_or_create_consumer(
+        self,
+        topic: str,
+        group_id: str,
+    ) -> AIOKafkaConsumer:
+        if group_id in self._consumers:
+            return self._consumers[group_id]
+
+        consumer = AIOKafkaConsumer(
+            topic,
+            bootstrap_servers=self.bootstrap_servers,
+            group_id=group_id,
+            enable_auto_commit=False,
+        )
+        await consumer.start()
+        self._consumers[group_id] = consumer
+        return consumer

--- a/components/bot_detector/event_queue/adapters/memory/__init__.py
+++ b/components/bot_detector/event_queue/adapters/memory/__init__.py
@@ -1,9 +1,11 @@
 from .adapter import InMemoryAdapter, InMemoryConsumerAdapter, InMemoryProducerAdapter
 from .config import InMemoryConfig
+from .lag_adapter import MemoryLagProbe
 
 __all__ = [
     "InMemoryAdapter",
     "InMemoryConsumerAdapter",
     "InMemoryProducerAdapter",
     "InMemoryConfig",
+    "MemoryLagProbe",
 ]

--- a/components/bot_detector/event_queue/adapters/memory/adapter.py
+++ b/components/bot_detector/event_queue/adapters/memory/adapter.py
@@ -60,9 +60,6 @@ class InMemoryConsumerAdapter(
     async def commit(self) -> Optional[Exception]:
         self._queue.task_done()
 
-    async def lag(self) -> int:
-        return self._queue.qsize()
-
 
 class InMemoryProducerAdapter(
     _InMemoryBase[T],
@@ -106,6 +103,3 @@ class InMemoryAdapter(QueueBackendProtocol[T]):
 
     async def commit(self) -> Optional[Exception]:
         return await self.consumer.commit()
-
-    async def lag(self) -> int:
-        return await self.consumer.lag()

--- a/components/bot_detector/event_queue/adapters/memory/lag_adapter.py
+++ b/components/bot_detector/event_queue/adapters/memory/lag_adapter.py
@@ -1,0 +1,12 @@
+from bot_detector.event_queue.lag_probe.interface import LagProbeProtocol
+
+
+class MemoryLagProbe(LagProbeProtocol):
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def lag(self, topic: str, group_id: str) -> int:
+        return 0

--- a/components/bot_detector/event_queue/core/event_queue.py
+++ b/components/bot_detector/event_queue/core/event_queue.py
@@ -64,9 +64,6 @@ class QueueConsumer(Generic[T]):
     async def get_many(self, count: int) -> list[T] | Exception:
         return await self._backend.get_many(count)
 
-    async def lag(self) -> int:
-        return await self._backend.lag()
-
     async def commit(self):
         return await self._backend.commit()
 

--- a/components/bot_detector/event_queue/core/interface.py
+++ b/components/bot_detector/event_queue/core/interface.py
@@ -36,8 +36,6 @@ class QueueBackendConsumerProtocol(Generic[T], Protocol):
 
     async def commit(self) -> Optional[Exception]: ...
 
-    async def lag(self) -> int: ...
-
 
 @runtime_checkable
 class QueueBackendProtocol(

--- a/components/bot_detector/event_queue/factory.py
+++ b/components/bot_detector/event_queue/factory.py
@@ -1,5 +1,9 @@
 from typing import Any, Literal, Type, TypeVar
 
+from bot_detector.event_queue.adapters.kafka import KafkaLagProbe
+from bot_detector.event_queue.adapters.memory import MemoryLagProbe
+from bot_detector.event_queue.lag_probe import LagProbeProtocol
+
 from bot_detector.event_queue.core import (
     Queue,
     QueueBackendConsumerProtocol,
@@ -68,6 +72,21 @@ def create_adapter_kafka(
         return AIOKafkaProducerAdapter[model](cls=model, config=config)
     else:  # consumer
         return AIOKafkaConsumerAdapter[model](cls=model, config=config)
+
+
+def create_lag_probe(
+    backend_type: Literal["memory", "kafka"],
+    bootstrap_servers: str | None = None,
+) -> LagProbeProtocol | Exception:
+    match backend_type:
+        case "memory":
+            return MemoryLagProbe()
+        case "kafka":
+            if bootstrap_servers is None:
+                return ValueError("bootstrap_servers is required for kafka lag probe")
+            return KafkaLagProbe(bootstrap_servers=bootstrap_servers)
+        case _:
+            return ValueError(f"Unknown backend_type: {backend_type}")
 
 
 class QueueFactory:

--- a/components/bot_detector/event_queue/lag_probe/__init__.py
+++ b/components/bot_detector/event_queue/lag_probe/__init__.py
@@ -1,0 +1,3 @@
+from .interface import LagProbeProtocol
+
+__all__ = ["LagProbeProtocol"]

--- a/components/bot_detector/event_queue/lag_probe/interface.py
+++ b/components/bot_detector/event_queue/lag_probe/interface.py
@@ -1,0 +1,10 @@
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LagProbeProtocol(Protocol):
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+    async def lag(self, topic: str, group_id: str) -> int: ...

--- a/test/components/bot_detector/event_queue/core/test_queue_factory.py
+++ b/test/components/bot_detector/event_queue/core/test_queue_factory.py
@@ -5,7 +5,12 @@ from bot_detector.event_queue.core.event_queue import (
     QueueConsumer,
     QueueProducer,
 )
-from bot_detector.event_queue.factory import InvalidConfig, QueueFactory
+from bot_detector.event_queue.factory import (
+    InvalidConfig,
+    QueueFactory,
+    create_lag_probe,
+)
+from bot_detector.event_queue.adapters.memory import MemoryLagProbe
 from pydantic import BaseModel
 
 
@@ -91,3 +96,16 @@ def test_queue_factory_raises_invalid_config():
             backend_type="memory",
             config=object(),
         )
+
+
+def test_create_lag_probe_memory():
+    lag_probe = create_lag_probe(backend_type="memory")
+
+    assert isinstance(lag_probe, MemoryLagProbe)
+
+
+def test_create_lag_probe_missing_bootstrap_servers():
+    lag_probe = create_lag_probe(backend_type="kafka")
+
+    assert isinstance(lag_probe, ValueError)
+    assert str(lag_probe) == "bootstrap_servers is required for kafka lag probe"


### PR DESCRIPTION
### Motivation
- Keep lag-probe implementations colocated with their concrete backends so each adapter owns its probe implementation and wiring. 
- Preserve a backend-agnostic contract for lag checks while removing `lag()` from queue protocols and queue wrappers to separate concerns.

### Description
- Added `LagProbeProtocol` contract in `components/bot_detector/event_queue/lag_probe/interface.py` and limited `lag_probe` package to expose only the protocol.
- Moved concrete lag probe implementations into adapter packages as `components/bot_detector/event_queue/adapters/kafka/lag_adapter.py` (`KafkaLagProbe`) and `components/bot_detector/event_queue/adapters/memory/lag_adapter.py` (`MemoryLagProbe`) and updated the adapter package exports to expose these classes.
- Updated `components/bot_detector/event_queue/factory.py` to import `KafkaLagProbe` and `MemoryLagProbe` from their adapter packages and added `create_lag_probe(...)` which returns an adapter-specific probe instance.
- Removed `lag()` from the consumer/backend protocols and queue wrappers and removed adapter-level `lag` methods so queues no longer provide lag measurement directly.
- Updated `bases/bot_detector/scrape_task_producer/core.py` to accept and use a `lag_probe` dependency (start/stop it and call `lag(topic, group_id)`), and adjusted queue config wiring to pass the same topic/group id used for lag probing.
- Updated tests to import `MemoryLagProbe` from the memory adapter package and added tests for `create_lag_probe` behavior.

### Testing
- Ran formatting check with `uv run ruff format --check .` which succeeded.
- Ran lint checks with `uv run ruff check .` which succeeded.
- Ran targeted tests with `uv run pytest test/components/bot_detector/event_queue test/bases/bot_detector/scrape_task_producer/test_core.py` which resulted in all tests passing (`60 passed`, 2 warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1bf30f6083258007c4d7d79b3328)