### PR TITLE
Gate worker_ml queue commits on successful fallback put

### DIFF
--- a/bases/bot_detector/worker_ml/core.py
+++ b/bases/bot_detector/worker_ml/core.py
@@ -132,7 +132,16 @@ async def consume_data_to_predict(
                     "error": str(e),
                 }
             )
-            await data_to_predict_queue.put(_batch)
+            put_result = await data_to_predict_queue.put(_batch)
+            if isinstance(put_result, Exception):
+                logger.error(
+                    {
+                        "error": "failed to requeue consumed records",
+                        "reason": str(put_result),
+                    }
+                )
+                await asyncio.sleep(15)
+                continue
             await data_to_predict_queue.commit()
             await asyncio.sleep(15)
             continue
@@ -159,7 +168,16 @@ async def consume_data_to_predict(
                     "error": str(e),
                 }
             )
-            await data_to_predict_queue.put(_batch)
+            put_result = await data_to_predict_queue.put(_batch)
+            if isinstance(put_result, Exception):
+                logger.error(
+                    {
+                        "error": "failed to requeue consumed records",
+                        "reason": str(put_result),
+                    }
+                )
+                await asyncio.sleep(15)
+                continue
             await data_to_predict_queue.commit()
             await asyncio.sleep(15)
             continue
@@ -220,7 +238,16 @@ async def consume_player_scraped(
                         "error": str(e),
                     }
                 )
-                await player_sc_queue.put(batch)
+                put_result = await player_sc_queue.put(batch)
+                if isinstance(put_result, Exception):
+                    logger.error(
+                        {
+                            "error": "failed to requeue consumed records",
+                            "reason": str(put_result),
+                        }
+                    )
+                    await asyncio.sleep(15)
+                    continue
                 await player_sc_queue.commit()
                 await asyncio.sleep(15)
                 continue
@@ -235,7 +262,16 @@ async def consume_player_scraped(
             logger.error(f"Error consuming scrapes: {e}")
             logger.debug(f"Traceback: \n{traceback.format_exc()}")
             if not isinstance(batch, Exception):
-                await player_sc_queue.put(batch)
+                put_result = await player_sc_queue.put(batch)
+                if isinstance(put_result, Exception):
+                    logger.error(
+                        {
+                            "error": "failed to requeue consumed records",
+                            "reason": str(put_result),
+                        }
+                    )
+                    await asyncio.sleep(15)
+                    continue
                 await player_sc_queue.commit()
             await asyncio.sleep(15)
 

--- a/test/bases/bot_detector/worker_ml/test_core.py
+++ b/test/bases/bot_detector/worker_ml/test_core.py
@@ -1,10 +1,169 @@
 import os
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock
+
+import pytest
 
 os.environ.setdefault("BASE_URL", "http://localhost")
 os.environ.setdefault("MODEL_NAME", "dummy")
 
+from bot_detector.event_queue.structs import DataToPredictStruct, ScrapedStruct
+from bot_detector.structs import HighscoreBaseStruct, MetaData, PlayerStruct
 from bot_detector.worker_ml import core
+
+
+class _StopLoop(BaseException):
+    pass
+
+
+@pytest.fixture
+def data_to_predict_batch() -> list[DataToPredictStruct]:
+    return [
+        DataToPredictStruct(
+            player_id=123,
+            data={"attack": 1},
+        )
+    ]
+
+
+@pytest.fixture
+def scraped_batch() -> list[ScrapedStruct]:
+    return [
+        ScrapedStruct(
+            metadata=MetaData(version=1, source="test"),
+            player_data=PlayerStruct(
+                id=123,
+                name="tester",
+                created_at=datetime.now(tz=UTC),
+            ),
+            highscore_data=HighscoreBaseStruct(
+                player_id=123,
+                scrape_date=date.today(),
+                time_to_live=date.today(),
+                skills={"attack": 10},
+                activities={},
+            ),
+        )
+    ]
 
 
 def test_sample():
     assert core is not None
+
+
+@pytest.mark.asyncio
+async def test_consume_data_to_predict_does_not_commit_when_requeue_fails_after_predict_error(
+    monkeypatch: pytest.MonkeyPatch,
+    data_to_predict_batch: list[DataToPredictStruct],
+) -> None:
+    queue = AsyncMock()
+    queue.get_many = AsyncMock(return_value=data_to_predict_batch)
+    queue.put = AsyncMock(return_value=Exception("requeue failed"))
+    queue.commit = AsyncMock()
+
+    monkeypatch.setattr(core, "predict", AsyncMock(side_effect=Exception("ml failed")))
+    monkeypatch.setattr(core.asyncio, "sleep", AsyncMock(side_effect=_StopLoop()))
+
+    with pytest.raises(_StopLoop):
+        await core.consume_data_to_predict(
+            max_messages=10,
+            data_to_predict_queue=queue,
+            api=AsyncMock(),
+            session_factory=AsyncMock(),
+        )
+
+    queue.put.assert_awaited_once_with(data_to_predict_batch)
+    queue.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_consume_data_to_predict_does_not_commit_when_requeue_fails_after_db_error(
+    monkeypatch: pytest.MonkeyPatch,
+    data_to_predict_batch: list[DataToPredictStruct],
+) -> None:
+    queue = AsyncMock()
+    queue.get_many = AsyncMock(return_value=data_to_predict_batch)
+    queue.put = AsyncMock(return_value=Exception("requeue failed"))
+    queue.commit = AsyncMock()
+
+    monkeypatch.setattr(
+        core,
+        "predict",
+        AsyncMock(return_value=[AsyncMock(model_dump=lambda: {"bot": 1.0})]),
+    )
+    monkeypatch.setattr(
+        core,
+        "insert_prediction_results",
+        AsyncMock(side_effect=Exception("db failed")),
+    )
+    monkeypatch.setattr(core.asyncio, "sleep", AsyncMock(side_effect=_StopLoop()))
+
+    with pytest.raises(_StopLoop):
+        await core.consume_data_to_predict(
+            max_messages=10,
+            data_to_predict_queue=queue,
+            api=AsyncMock(),
+            session_factory=AsyncMock(),
+        )
+
+    queue.put.assert_awaited_once_with(data_to_predict_batch)
+    queue.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_consume_player_scraped_does_not_commit_when_requeue_fails_after_predict_error(
+    monkeypatch: pytest.MonkeyPatch,
+    scraped_batch: list[ScrapedStruct],
+) -> None:
+    queue = AsyncMock()
+    queue.get_many = AsyncMock(return_value=scraped_batch)
+    queue.put = AsyncMock(return_value=Exception("requeue failed"))
+    queue.commit = AsyncMock()
+
+    monkeypatch.setattr(core, "predict", AsyncMock(side_effect=Exception("ml failed")))
+    monkeypatch.setattr(core.asyncio, "sleep", AsyncMock(side_effect=_StopLoop()))
+
+    with pytest.raises(_StopLoop):
+        await core.consume_player_scraped(
+            max_messages=10,
+            player_sc_queue=queue,
+            api=AsyncMock(),
+            session_factory=AsyncMock(),
+        )
+
+    queue.put.assert_awaited_once_with(scraped_batch)
+    queue.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_consume_player_scraped_does_not_commit_when_requeue_fails_in_outer_handler(
+    monkeypatch: pytest.MonkeyPatch,
+    scraped_batch: list[ScrapedStruct],
+) -> None:
+    queue = AsyncMock()
+    queue.get_many = AsyncMock(return_value=scraped_batch)
+    queue.put = AsyncMock(return_value=Exception("requeue failed"))
+    queue.commit = AsyncMock()
+
+    monkeypatch.setattr(
+        core,
+        "predict",
+        AsyncMock(return_value=[AsyncMock(model_dump=lambda: {"bot": 1.0})]),
+    )
+    monkeypatch.setattr(
+        core,
+        "insert_prediction_results",
+        AsyncMock(side_effect=Exception("db failed")),
+    )
+    monkeypatch.setattr(core.asyncio, "sleep", AsyncMock(side_effect=_StopLoop()))
+
+    with pytest.raises(_StopLoop):
+        await core.consume_player_scraped(
+            max_messages=10,
+            player_sc_queue=queue,
+            api=AsyncMock(),
+            session_factory=AsyncMock(),
+        )
+
+    queue.put.assert_awaited_once_with(scraped_batch)
+    queue.commit.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Ensure the worker does not commit consumed offsets when a fallback requeue write fails, preventing data loss when `put(...)` returns an `Exception`.
- Make requeue error handling explicit by surfacing and logging backend `put` failures before deciding to commit.
- Add regression tests to prevent regressions around requeue-vs-commit semantics.

### Description
- In `bases/bot_detector/worker_ml/core.py`, capture the result of `put(...)` in all requeue-on-error branches inside `consume_data_to_predict` and `consume_player_scraped`, and only call `commit()` when `put(...)` did not return an `Exception`.
- When `put_result` is an `Exception`, log a clear error message and skip the commit and proceed to sleep/retry.
- Added async tests in `test/bases/bot_detector/worker_ml/test_core.py` that assert commit is not called when `put(...)` returns an `Exception` for both predict and DB-error paths in both workers.

### Testing
- Ran `uv run pytest test/bases/bot_detector/worker_ml/test_core.py`, all tests passed (`5 passed`).
- Ran `uv run ruff format --check .` to ensure formatting, which passed after formatting the new test file.
- Verified the modified worker code paths by exercising the test scenarios that simulate `predict` and DB failures and a failing `put(...)` to confirm no commit occurs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3288cbc88325bf177fa1aeb75c6f)