### PR TITLE
Commit consumed hiscore messages only after successful publish

### DIFF
--- a/bases/bot_detector/hiscore_scraper/core.py
+++ b/bases/bot_detector/hiscore_scraper/core.py
@@ -306,6 +306,14 @@ async def work(
                     f"[{worker_id}][{player_data.name}]: Failed to publish scraped data: {produce_error}"
                 )
                 continue
+
+            commit_error = await player_ts_queue.commit()
+            if commit_error:
+                logger.error(
+                    f"[{worker_id}][{player_data.name}]: Failed to commit consumed message: {commit_error}"
+                )
+                continue
+
             logger.debug(f"[{worker_id}][{player_data.name}]: scraped successfully.")
 
 

--- a/test/bases/bot_detector/hiscore_scraper/test_core.py
+++ b/test/bases/bot_detector/hiscore_scraper/test_core.py
@@ -1,5 +1,147 @@
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from bot_detector.event_queue.structs import ScrapedStruct, ToScrapeStruct
 from bot_detector.hiscore_scraper import core
+from bot_detector.structs import HighscoreBaseStruct, MetaData, PlayerStruct
 
 
-def test_sample():
-    assert core is not None
+class _DummySession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _to_scrape_player() -> ToScrapeStruct:
+    player = PlayerStruct(
+        id=1,
+        name="player-1",
+        created_at=datetime(2024, 1, 1),
+    )
+    return ToScrapeStruct(
+        metadata=MetaData(version=1, source="test"),
+        player_data=player,
+    )
+
+
+def _scraped_player() -> ScrapedStruct:
+    player = PlayerStruct(
+        id=1,
+        name="player-1",
+        created_at=datetime(2024, 1, 1),
+    )
+    return ScrapedStruct(
+        metadata=MetaData(version=1, source="test"),
+        player_data=player,
+        highscore_data=HighscoreBaseStruct(
+            player_id=1,
+            scrape_date=datetime(2024, 1, 1).date(),
+            skills={},
+            activities={},
+            time_to_live=datetime(2024, 1, 31).date(),
+        ),
+    )
+
+
+def _patch_common(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(core, "ClientSession", lambda *args, **kwargs: _DummySession())
+    monkeypatch.setattr(core, "RateLimiter", lambda *args, **kwargs: object())
+    monkeypatch.setattr(core, "Hiscore", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        core,
+        "ProxySettings",
+        lambda: SimpleNamespace(MAX_CALLS=100, INTERVAL=60),
+    )
+    monkeypatch.setattr(
+        core,
+        "get_proxy",
+        AsyncMock(side_effect=["user@proxy", asyncio.CancelledError()]),
+    )
+    monkeypatch.setattr(
+        core, "get_player_to_scrape", AsyncMock(return_value=_to_scrape_player())
+    )
+
+
+@pytest.mark.asyncio
+async def test_work_commits_after_successful_publish(monkeypatch: pytest.MonkeyPatch):
+    _patch_common(monkeypatch)
+
+    player_ts_queue = AsyncMock()
+    player_ts_queue.commit = AsyncMock(return_value=None)
+
+    player_sc_producer = AsyncMock()
+    player_sc_producer.put = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(
+        core, "scrape_player", AsyncMock(return_value=(object(), False))
+    )
+    monkeypatch.setattr(
+        core, "transform_player_stats", AsyncMock(return_value=_scraped_player())
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await core.work(
+            worker_id=1,
+            proxy_manager=AsyncMock(),
+            player_ts_queue=player_ts_queue,
+            player_nf_producer=AsyncMock(),
+            player_sc_producer=player_sc_producer,
+        )
+
+    player_ts_queue.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_work_does_not_commit_on_retry(monkeypatch: pytest.MonkeyPatch):
+    _patch_common(monkeypatch)
+
+    player_ts_queue = AsyncMock()
+    player_ts_queue.commit = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(core, "scrape_player", AsyncMock(return_value=(None, True)))
+    monkeypatch.setattr(core, "handle_retry", AsyncMock())
+
+    with pytest.raises(asyncio.CancelledError):
+        await core.work(
+            worker_id=1,
+            proxy_manager=AsyncMock(),
+            player_ts_queue=player_ts_queue,
+            player_nf_producer=AsyncMock(),
+            player_sc_producer=AsyncMock(),
+        )
+
+    player_ts_queue.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_work_does_not_commit_when_publish_fails(monkeypatch: pytest.MonkeyPatch):
+    _patch_common(monkeypatch)
+
+    player_ts_queue = AsyncMock()
+    player_ts_queue.commit = AsyncMock(return_value=None)
+
+    player_sc_producer = AsyncMock()
+    player_sc_producer.put = AsyncMock(return_value=Exception("publish failed"))
+
+    monkeypatch.setattr(
+        core, "scrape_player", AsyncMock(return_value=(object(), False))
+    )
+    monkeypatch.setattr(
+        core, "transform_player_stats", AsyncMock(return_value=_scraped_player())
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await core.work(
+            worker_id=1,
+            proxy_manager=AsyncMock(),
+            player_ts_queue=player_ts_queue,
+            player_nf_producer=AsyncMock(),
+            player_sc_producer=player_sc_producer,
+        )
+
+    player_ts_queue.commit.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Ensure a consumed `players.to_scrape` message is only acknowledged after the scraped result is durably published to `players.scraped` to avoid losing messages when publish fails. 
- Prevent commits on retry/error branches so messages remain available for reprocessing.

### Description
- Added `await player_ts_queue.commit()` immediately after a successful `player_sc_producer.put([scraped_data])` call inside `work(...)` in `bases/bot_detector/hiscore_scraper/core.py` and log/`continue` on commit errors. 
- Commit is intentionally not invoked in retry branches or when publish fails. 
- Added async unit tests in `test/bases/bot_detector/hiscore_scraper/test_core.py` that mock dependencies and assert that commit is called on successful publish and not called on retry or publish-error paths.

### Testing
- Ran formatting checks with `uv run ruff format --check .` and formatted the new test file with `uv run ruff format` where needed. 
- Executed the new unit tests with `uv run pytest test/bases/bot_detector/hiscore_scraper/test_core.py`, which returned `3 passed`. 
- All automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3285d76c8325b14dd96d1d0cffd0)