### PR TITLE
Commit offsets only after successful Runemetrics handling/requeue

### DIFF
--- a/bases/bot_detector/runemetrics_scraper/core.py
+++ b/bases/bot_detector/runemetrics_scraper/core.py
@@ -209,6 +209,8 @@ async def work(
                     logger.error(
                         f"[{worker_id}]: Failed to requeue player: {produce_error}"
                     )
+                else:
+                    await player_nf_queue.commit()
                 await asyncio.sleep(10)
                 continue
 
@@ -232,6 +234,8 @@ async def work(
                     logger.error(
                         f"[{worker_id}]: Failed to requeue player: {produce_error}"
                     )
+                else:
+                    await player_nf_queue.commit()
                 continue
 
             # push data to kafka
@@ -242,6 +246,7 @@ async def work(
                     f"[{worker_id}]: Failed to produce scraped player: {produce_error}"
                 )
                 continue
+            await player_nf_queue.commit()
             logger.debug(
                 f"[{worker_id}][{player_data.name}]: {player_data.label_jagex=}"
             )

--- a/test/bases/bot_detector/runemetrics_scraper/test_core.py
+++ b/test/bases/bot_detector/runemetrics_scraper/test_core.py
@@ -1,10 +1,13 @@
 import os
+from unittest.mock import AsyncMock
 from datetime import datetime, timedelta
+import asyncio
 
 import pytest
+from bot_detector.event_queue.structs import NotFoundStruct
 from bot_detector.runemetrics_api.core import RuneMetricsError, RuneMetricsResponse
 from bot_detector.runemetrics_scraper import core
-from bot_detector.structs import PlayerStruct
+from bot_detector.structs import MetaData, PlayerStruct
 from pydantic import BaseModel
 
 os.environ["ENVIRONMENT"] = "test"
@@ -63,3 +66,100 @@ async def test_update_player(player_struct: PlayerStruct, error_value, expected_
     assert updated.possible_ban == 1
     assert updated.confirmed_player == 0
     assert isinstance(updated.updated_at, datetime)
+
+
+class _DummySession:
+    async def __aenter__(self):
+        return object()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_work_commits_offset_after_successful_handle(
+    monkeypatch: pytest.MonkeyPatch,
+    player_struct: PlayerStruct,
+):
+    player_message = NotFoundStruct(
+        metadata=MetaData(version=1, source="test"),
+        player_data=player_struct,
+    )
+    player_nf_queue = AsyncMock()
+    player_nf_queue.get_one = AsyncMock(return_value=player_message)
+    player_nf_queue.commit = AsyncMock(return_value=None)
+    player_sc_producer = AsyncMock()
+    player_sc_producer.put = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(core, "ClientSession", _DummySession)
+    monkeypatch.setattr(
+        core,
+        "get_proxy",
+        AsyncMock(side_effect=["http://user@proxy", asyncio.CancelledError()]),
+    )
+    monkeypatch.setattr(
+        core,
+        "scrape_player",
+        AsyncMock(return_value=(RuneMetricsResponse(), 0.1, None)),
+    )
+    monkeypatch.setattr(core.asyncio, "sleep", AsyncMock(return_value=None))
+
+    with pytest.raises(asyncio.CancelledError):
+        await core.work(
+            worker_id=1,
+            proxy_manager=AsyncMock(),
+            rate_limiter=AsyncMock(),
+            player_nf_queue=player_nf_queue,
+            player_sc_producer=player_sc_producer,
+        )
+
+    player_nf_queue.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "requeue_error,expected_commit_calls",
+    [
+        (None, 1),
+        (Exception("requeue failed"), 0),
+    ],
+)
+async def test_work_commits_only_after_successful_requeue(
+    monkeypatch: pytest.MonkeyPatch,
+    player_struct: PlayerStruct,
+    requeue_error: Exception | None,
+    expected_commit_calls: int,
+):
+    player_message = NotFoundStruct(
+        metadata=MetaData(version=1, source="test"),
+        player_data=player_struct,
+    )
+    player_nf_queue = AsyncMock()
+    player_nf_queue.get_one = AsyncMock(return_value=player_message)
+    player_nf_queue.put = AsyncMock(return_value=requeue_error)
+    player_nf_queue.commit = AsyncMock(return_value=None)
+    player_sc_producer = AsyncMock()
+
+    monkeypatch.setattr(core, "ClientSession", _DummySession)
+    monkeypatch.setattr(
+        core,
+        "get_proxy",
+        AsyncMock(side_effect=["http://user@proxy", asyncio.CancelledError()]),
+    )
+    monkeypatch.setattr(
+        core,
+        "scrape_player",
+        AsyncMock(return_value=(None, None, "temporary failure")),
+    )
+    monkeypatch.setattr(core.asyncio, "sleep", AsyncMock(return_value=None))
+
+    with pytest.raises(asyncio.CancelledError):
+        await core.work(
+            worker_id=1,
+            proxy_manager=AsyncMock(),
+            rate_limiter=AsyncMock(),
+            player_nf_queue=player_nf_queue,
+            player_sc_producer=player_sc_producer,
+        )
+
+    assert player_nf_queue.commit.await_count == expected_commit_calls


### PR DESCRIPTION
### Motivation
- Prevent message loss by ensuring consumer offsets are committed only once a message has been successfully handled or requeued.  
- Avoid committing offsets when a requeue fails, so messages remain available for retry.  
- Make the offset-commit behavior explicit in the runemetrics scraper worker to improve reliability.

### Description
- In `bases/bot_detector/runemetrics_scraper/core.py`, add `await player_nf_queue.commit()` after a successful downstream publish (`player_sc_producer.put([scraped_data])`).  
- In the scrape-error and validation-error branches, call `await player_nf_queue.commit()` only when `player_nf_queue.put([player])` returns no error.  
- Add tests in `test/bases/bot_detector/runemetrics_scraper/test_core.py` to assert commit behavior for the success path and conditional commits when requeuing, using `AsyncMock` and `pytest.mark.asyncio`.

### Testing
- Ran formatting check with `uv run ruff format` and lint check with `uv run ruff check`, both passed.  
- Ran targeted tests with `uv run pytest test/bases/bot_detector/runemetrics_scraper/test_core.py`, and all tests succeeded (`8 passed`).  
- The change touches `bases/bot_detector/runemetrics_scraper/core.py` and `test/bases/bot_detector/runemetrics_scraper/test_core.py` and is covered by the added unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a32865d248325ad989b0a90512753)