### PR TITLE
Handle ClientHttpProxyError in hiscore scraper

### DIFF
--- a/bases/bot_detector/hiscore_scraper/core.py
+++ b/bases/bot_detector/hiscore_scraper/core.py
@@ -118,7 +118,10 @@ async def scrape_player(
     session: ClientSession,
     hiscore_instance: Hiscore,
     proxy: str,
-) -> tuple[PlayerStats | None, Exception | None]:
+) -> tuple[
+    PlayerStats | None,
+    PlayerDoesNotExist | UnexpectedRedirection | aiohttp.ClientError | asyncio.TimeoutError | None,
+]:
     """
     Scrape player stats from hiscores.
     Returns a tuple of (PlayerStats | None, Exception | None).

--- a/bases/bot_detector/hiscore_scraper/core.py
+++ b/bases/bot_detector/hiscore_scraper/core.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from datetime import date, datetime, timedelta
+from unittest import case
 
 import aiohttp
 from aiohttp import ClientSession
@@ -302,7 +303,7 @@ async def work(
                 hiscore_instance=hiscore_instance,
                 proxy=_proxy,
             )
-
+        
             if error:
                 log_prefix = f"[{worker_id}][{player_data.name}]"
                 error_counter.labels(proxy=_proxy).inc()
@@ -311,7 +312,7 @@ async def work(
                 if isinstance(error, aiohttp.ClientHttpProxyError):
                     await proxy_manager.rotate_proxies()
                     await asyncio.sleep(10)
-
+                
                 if isinstance(error, PlayerDoesNotExist):
                     not_found_counter.labels(proxy=_proxy).inc()
                     logger.debug(f"{log_prefix}: not found.")
@@ -329,6 +330,7 @@ async def work(
             success_counter.labels(proxy=_proxy).inc()
 
             # transform player stats to hiscore data
+            assert player_stats is not None  # for mypy
             scraped_data = await transform_player_stats(
                 player_stats=player_stats,
                 player=player_data,

--- a/bases/bot_detector/hiscore_scraper/core.py
+++ b/bases/bot_detector/hiscore_scraper/core.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from datetime import date, datetime, timedelta
-from unittest import case
 
 import aiohttp
 from aiohttp import ClientSession
@@ -121,7 +120,11 @@ async def scrape_player(
     proxy: str,
 ) -> tuple[
     PlayerStats | None,
-    PlayerDoesNotExist | UnexpectedRedirection | aiohttp.ClientError | asyncio.TimeoutError | None,
+    PlayerDoesNotExist
+    | UnexpectedRedirection
+    | aiohttp.ClientError
+    | asyncio.TimeoutError
+    | None,
 ]:
     """
     Scrape player stats from hiscores.
@@ -303,23 +306,30 @@ async def work(
                 hiscore_instance=hiscore_instance,
                 proxy=_proxy,
             )
-        
+
             if error:
                 log_prefix = f"[{worker_id}][{player_data.name}]"
                 error_counter.labels(proxy=_proxy).inc()
                 logger.warning(f"{log_prefix}: {error=}")
 
                 if isinstance(error, aiohttp.ClientHttpProxyError):
-                    await proxy_manager.rotate_proxies()
-                    await asyncio.sleep(10)
-                
+                    if error.status == 407:
+                        await proxy_manager.rotate_proxies()
+                        await asyncio.sleep(10)
+                    else:
+                        logger.warning(
+                            f"{log_prefix}: Proxy error (status={error.status}): {error.message}"
+                        )
+
                 if isinstance(error, PlayerDoesNotExist):
                     not_found_counter.labels(proxy=_proxy).inc()
                     logger.debug(f"{log_prefix}: not found.")
                     player_data.possible_ban = True
                     err = await produce_not_found(player_nf_producer, player_data)
                     if err:
-                        logger.error(f"{log_prefix}: Failed to publish not_found: {err}")
+                        logger.error(
+                            f"{log_prefix}: Failed to publish not_found: {err}"
+                        )
                 else:
                     err = await produce_player_to_scrape(player_ts_queue, player_data)
                     if err:

--- a/bases/bot_detector/hiscore_scraper/core.py
+++ b/bases/bot_detector/hiscore_scraper/core.py
@@ -114,20 +114,16 @@ async def produce_player_scraped(
 
 
 async def scrape_player(
-    worker_id: int,
     player: PlayerStruct,
     session: ClientSession,
     hiscore_instance: Hiscore,
     proxy: str,
-    player_nf_producer: QueueProducer[NotFoundStruct],
-    player_ts_queue: Queue[ToScrapeStruct],
-) -> tuple[PlayerStats | None, bool]:
+) -> tuple[PlayerStats | None, Exception | None]:
     """
     Scrape player stats from hiscores.
-    Returns a tuple of (PlayerStats | None, bool) where the bool indicates
-    whether to retry scraping the player.
+    Returns a tuple of (PlayerStats | None, Exception | None).
+    Caller handles error-based logic (retry, not_found, proxy refresh).
     """
-    log_prefix = f"[{worker_id}][{player.name}]"
     try:
         hiscore_data = await hiscore_instance.get(
             mode=HSMode.OLDSCHOOL,
@@ -140,35 +136,20 @@ async def scrape_player(
             latency_histogram.labels(proxy=proxy).observe(latency)
         else:
             player_stats = hiscore_data
-        return player_stats, False
-    except PlayerDoesNotExist:
-        not_found_counter.labels(proxy=proxy).inc()
-        logger.debug(f"{log_prefix}: not found.")
-        player.possible_ban = True
-        error = await produce_not_found(player_nf_producer, player)
-        if error:
-            logger.error(f"{log_prefix}: Failed to publish not_found: {error}")
-        return None, False
+        return player_stats, None
+    except PlayerDoesNotExist as e:
+        return None, e
     except UnexpectedRedirection as e:
-        error_counter.labels(proxy=proxy).inc()
-        logger.warning(f"{log_prefix}: {e=}")
-        error = await produce_player_to_scrape(player_ts_queue, player)
-        if error:
-            logger.error(f"{log_prefix}: Failed to requeue scrape: {error}")
-        return None, True
+        return None, e
     except (
         aiohttp.ClientResponseError,
+        aiohttp.ClientHttpProxyError,
         aiohttp.ConnectionTimeoutError,
         aiohttp.ClientConnectorError,
         aiohttp.ServerDisconnectedError,
         asyncio.TimeoutError,
     ) as e:
-        error_counter.labels(proxy=proxy).inc()
-        logger.warning(f"{log_prefix}: {e=}")
-        error = await produce_player_to_scrape(player_ts_queue, player)
-        if error:
-            logger.error(f"{log_prefix}: Failed to requeue scrape: {error}")
-        return None, True
+        return None, e
 
 
 async def transform_player_stats(
@@ -312,17 +293,33 @@ async def work(
             # metric: every time we scrape a player, we increment the counter
             total_counter.labels(proxy=_proxy).inc()
 
-            player_stats, retry = await scrape_player(
+            player_stats, error = await scrape_player(
                 player=player_data,
                 session=session,
                 hiscore_instance=hiscore_instance,
                 proxy=_proxy,
-                worker_id=worker_id,
-                player_nf_producer=player_nf_producer,
-                player_ts_queue=player_ts_queue,
             )
-            if player_stats is None:
-                if retry:
+
+            if error:
+                log_prefix = f"[{worker_id}][{player_data.name}]"
+                error_counter.labels(proxy=_proxy).inc()
+                logger.warning(f"{log_prefix}: {error=}")
+
+                if isinstance(error, aiohttp.ClientHttpProxyError):
+                    await proxy_manager.rotate_proxies()
+                    await asyncio.sleep(10)
+
+                if isinstance(error, PlayerDoesNotExist):
+                    not_found_counter.labels(proxy=_proxy).inc()
+                    logger.debug(f"{log_prefix}: not found.")
+                    player_data.possible_ban = True
+                    err = await produce_not_found(player_nf_producer, player_data)
+                    if err:
+                        logger.error(f"{log_prefix}: Failed to publish not_found: {err}")
+                else:
+                    err = await produce_player_to_scrape(player_ts_queue, player_data)
+                    if err:
+                        logger.error(f"{log_prefix}: Failed to requeue scrape: {err}")
                     await handle_retry(retry_tracker, worker_id, proxy)
                 continue
 

--- a/components/bot_detector/proxy_manager/core.py
+++ b/components/bot_detector/proxy_manager/core.py
@@ -51,8 +51,6 @@ class ProxyManager:
         self._rotate_lock = asyncio.Lock()
         self._last_rotate: float = 0.0
         self._rotate_cooldown = rotate_cooldown_seconds
-        self._rotating = False
-        self._rotate_done = asyncio.Event()
 
         if not api_key:
             raise Exception("No API key provided")
@@ -124,30 +122,13 @@ class ProxyManager:
     async def rotate_proxies(self):
         """
         Rotate proxies by fetching a fresh list from the API.
-        Coalesces concurrent calls: if rotation is in progress, waits for it.
         Skips if a rotation completed recently within the cooldown window.
         """
-        need_wait = False
         async with self._rotate_lock:
-            if self._rotating:
-                need_wait = True
-            else:
-                now = time.time()
-                if now - self._last_rotate < self._rotate_cooldown:
-                    logger.info("Skipping rotation - cooldown not elapsed")
-                    return
-                self._rotating = True
-                self._rotate_done.clear()
-
-        if need_wait:
-            await self._rotate_done.wait()
-            return
-
-        try:
+            now = time.time()
+            if now - self._last_rotate < self._rotate_cooldown:
+                logger.info("Skipping rotation - cooldown not elapsed")
+                return
             logger.info("Rotating proxies...")
             await self.fetch_proxies()
             self._last_rotate = time.time()
-        finally:
-            async with self._rotate_lock:
-                self._rotating = False
-            self._rotate_done.set()

--- a/components/bot_detector/proxy_manager/core.py
+++ b/components/bot_detector/proxy_manager/core.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 
 from aiohttp import ClientSession
 from pydantic import BaseModel, Field
@@ -32,23 +33,29 @@ class Proxy(BaseModel):
 
 
 class ProxyManager:
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, rotate_cooldown_seconds: float = 30.0) -> None:
         """
         Initialize the Webshare API client.
 
         Args:
             api_key (str): API key for authenticating with Webshare.
+            rotate_cooldown_seconds (float): Minimum seconds between proxy rotations.
         """
         referral = "https://www.webshare.io/?referral_code=qvpjdwxqsblt"
         print(f"To get an API key, please use our referral code: {referral}")
 
         self.URL = "https://proxy.webshare.io/api/proxy/list/"
         self.api_key = api_key
-        self.proxy_list = []  # Holds the list of proxies
-        self.lock = asyncio.Lock()  # Lock for thread-safe access to proxy list
+        self.proxy_list = []
+        self.lock = asyncio.Lock()
+        self._rotate_lock = asyncio.Lock()
+        self._last_rotate: float = 0.0
+        self._rotate_cooldown = rotate_cooldown_seconds
+        self._rotating = False
+        self._rotate_done = asyncio.Event()
 
         if not api_key:
-            raise Exception("No API key provided")  # Ensure an API key is supplied
+            raise Exception("No API key provided")
 
     async def _fetch(
         self, session: ClientSession, url: str, headers: dict
@@ -117,6 +124,30 @@ class ProxyManager:
     async def rotate_proxies(self):
         """
         Rotate proxies by fetching a fresh list from the API.
+        Coalesces concurrent calls: if rotation is in progress, waits for it.
+        Skips if a rotation completed recently within the cooldown window.
         """
-        logger.info("Rotating proxies...")
-        await self.fetch_proxies()
+        need_wait = False
+        async with self._rotate_lock:
+            if self._rotating:
+                need_wait = True
+            else:
+                now = time.time()
+                if now - self._last_rotate < self._rotate_cooldown:
+                    logger.info("Skipping rotation - cooldown not elapsed")
+                    return
+                self._rotating = True
+                self._rotate_done.clear()
+
+        if need_wait:
+            await self._rotate_done.wait()
+            return
+
+        try:
+            logger.info("Rotating proxies...")
+            await self.fetch_proxies()
+            self._last_rotate = time.time()
+        finally:
+            async with self._rotate_lock:
+                self._rotating = False
+            self._rotate_done.set()

--- a/components/bot_detector/proxy_manager/core.py
+++ b/components/bot_detector/proxy_manager/core.py
@@ -46,7 +46,7 @@ class ProxyManager:
 
         self.URL = "https://proxy.webshare.io/api/proxy/list/"
         self.api_key = api_key
-        self.proxy_list = []
+        self.proxy_list: list[str] = []
         self.lock = asyncio.Lock()
         self._rotate_lock = asyncio.Lock()
         self._last_rotate: float = 0.0

--- a/test/bases/bot_detector/hiscore_scraper/test_core.py
+++ b/test/bases/bot_detector/hiscore_scraper/test_core.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import aiohttp
 import pytest
+from aiohttp import RequestInfo
 from bot_detector.event_queue.structs import ScrapedStruct, ToScrapeStruct
 from bot_detector.hiscore_scraper import core
 from bot_detector.structs import HighscoreBaseStruct, MetaData, PlayerStruct
@@ -90,7 +92,7 @@ async def test_work_requeues_player_when_publish_fails(monkeypatch: pytest.Monke
     player_sc_producer = AsyncMock()
 
     monkeypatch.setattr(
-        core, "scrape_player", AsyncMock(return_value=(object(), False))
+        core, "scrape_player", AsyncMock(return_value=(object(), None))
     )
     monkeypatch.setattr(
         core, "transform_player_stats", AsyncMock(return_value=_scraped_player())
@@ -113,5 +115,47 @@ async def test_work_requeues_player_when_publish_fails(monkeypatch: pytest.Monke
         )
 
     produce_player_to_scrape.assert_awaited_once()
-    requeued_player = produce_player_to_scrape.await_args.args[1]
+    call_args = produce_player_to_scrape.await_args
+    assert call_args is not None
+    requeued_player = call_args.args[1]
     assert requeued_player.name == "player-1"
+
+
+@pytest.mark.asyncio
+async def test_work_refreshes_proxies_on_proxy_error(monkeypatch: pytest.MonkeyPatch):
+    _patch_common(monkeypatch)
+
+    player_ts_queue = AsyncMock()
+    player_sc_producer = AsyncMock()
+    proxy_manager = AsyncMock()
+
+    proxy_error = aiohttp.ClientHttpProxyError(
+        request_info=RequestInfo(
+            url="http://example.com",
+            method="GET",
+            headers={},
+        ),
+        history=(),
+        status=407,
+        message="Proxy Authentication Required",
+    )
+    monkeypatch.setattr(
+        core, "scrape_player", AsyncMock(return_value=(None, proxy_error))
+    )
+    monkeypatch.setattr(core, "produce_player_to_scrape", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        core,
+        "produce_player_scraped",
+        AsyncMock(return_value=Exception("should not be called")),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await core.work(
+            worker_id=1,
+            proxy_manager=proxy_manager,
+            player_ts_queue=player_ts_queue,
+            player_nf_producer=AsyncMock(),
+            player_sc_producer=player_sc_producer,
+        )
+
+    proxy_manager.rotate_proxies.assert_awaited_once()

--- a/test/bases/bot_detector/hiscore_scraper/test_core.py
+++ b/test/bases/bot_detector/hiscore_scraper/test_core.py
@@ -91,9 +91,7 @@ async def test_work_requeues_player_when_publish_fails(monkeypatch: pytest.Monke
     player_ts_queue = AsyncMock()
     player_sc_producer = AsyncMock()
 
-    monkeypatch.setattr(
-        core, "scrape_player", AsyncMock(return_value=(object(), None))
-    )
+    monkeypatch.setattr(core, "scrape_player", AsyncMock(return_value=(object(), None)))
     monkeypatch.setattr(
         core, "transform_player_stats", AsyncMock(return_value=_scraped_player())
     )

--- a/test/components/bot_detector/proxy_manager/test_core.py
+++ b/test/components/bot_detector/proxy_manager/test_core.py
@@ -103,20 +103,21 @@ async def test_rotate_proxies_cooldown_skips_rapid_calls():
 
 
 @pytest.mark.asyncio
-async def test_rotate_proxies_coalesces_concurrent_calls():
+async def test_rotate_proxies_serializes_concurrent_calls():
     """
-    Test that concurrent rotate_proxies calls are coalesced into a single fetch.
+    Test that concurrent rotate_proxies calls are serialized via lock.
+    With cooldown=0, each call will fetch (no coalescing).
     """
     import asyncio
 
     proxy_manager = ProxyManager(api_key="test-key", rotate_cooldown_seconds=0.0)
 
-    fetch_count = 0
+    fetch_order = []
 
     async def fake_fetch():
-        nonlocal fetch_count
-        fetch_count += 1
+        fetch_order.append("start")
         await asyncio.sleep(0.05)
+        fetch_order.append("end")
         return ["http://proxy:8080"]
 
     with patch.object(
@@ -128,4 +129,5 @@ async def test_rotate_proxies_coalesces_concurrent_calls():
             proxy_manager.rotate_proxies(),
         )
 
-    assert fetch_count == 1
+    assert len(fetch_order) == 6
+    assert fetch_order == ["start", "end", "start", "end", "start", "end"]

--- a/test/components/bot_detector/proxy_manager/test_core.py
+++ b/test/components/bot_detector/proxy_manager/test_core.py
@@ -120,9 +120,7 @@ async def test_rotate_proxies_serializes_concurrent_calls():
         fetch_order.append("end")
         return ["http://proxy:8080"]
 
-    with patch.object(
-        proxy_manager, "fetch_proxies", side_effect=fake_fetch
-    ):
+    with patch.object(proxy_manager, "fetch_proxies", side_effect=fake_fetch):
         await asyncio.gather(
             proxy_manager.rotate_proxies(),
             proxy_manager.rotate_proxies(),

--- a/test/components/bot_detector/proxy_manager/test_core.py
+++ b/test/components/bot_detector/proxy_manager/test_core.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from unittest.mock import AsyncMock, patch
 
@@ -108,8 +109,6 @@ async def test_rotate_proxies_serializes_concurrent_calls():
     Test that concurrent rotate_proxies calls are serialized via lock.
     With cooldown=0, each call will fetch (no coalescing).
     """
-    import asyncio
-
     proxy_manager = ProxyManager(api_key="test-key", rotate_cooldown_seconds=0.0)
 
     fetch_order = []

--- a/test/components/bot_detector/proxy_manager/test_core.py
+++ b/test/components/bot_detector/proxy_manager/test_core.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from bot_detector.proxy_manager import ProxyManager
@@ -82,3 +83,49 @@ async def test_get_proxy_index_error():
     proxy, error = await proxy_manager.get_proxy(index=len(proxies) + 1)
     assert isinstance(error, IndexError)
     assert proxy is None
+
+
+@pytest.mark.asyncio
+async def test_rotate_proxies_cooldown_skips_rapid_calls():
+    """
+    Test that rotate_proxies skips when called within cooldown window.
+    """
+    proxy_manager = ProxyManager(api_key="test-key", rotate_cooldown_seconds=10.0)
+
+    with patch.object(
+        proxy_manager, "fetch_proxies", new_callable=AsyncMock
+    ) as mock_fetch:
+        await proxy_manager.rotate_proxies()
+        assert mock_fetch.call_count == 1
+
+        await proxy_manager.rotate_proxies()
+        assert mock_fetch.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_rotate_proxies_coalesces_concurrent_calls():
+    """
+    Test that concurrent rotate_proxies calls are coalesced into a single fetch.
+    """
+    import asyncio
+
+    proxy_manager = ProxyManager(api_key="test-key", rotate_cooldown_seconds=0.0)
+
+    fetch_count = 0
+
+    async def fake_fetch():
+        nonlocal fetch_count
+        fetch_count += 1
+        await asyncio.sleep(0.05)
+        return ["http://proxy:8080"]
+
+    with patch.object(
+        proxy_manager, "fetch_proxies", side_effect=fake_fetch
+    ):
+        await asyncio.gather(
+            proxy_manager.rotate_proxies(),
+            proxy_manager.rotate_proxies(),
+            proxy_manager.rotate_proxies(),
+        )
+
+    assert fetch_count == 1


### PR DESCRIPTION
## Summary
- Fixes #96
- Refactors `scrape_player()` to return errors as values `tuple[PlayerStats | None, Exception | None]`
- Adds `ClientHttpProxyError` handling with automatic proxy refresh on HTTP 407
- Moves side effects (logging, metrics, requeue) to `work()` caller for cleaner separation

## Changes
- `scrape_player()`: Now a pure function with no side effects, returns exception types
- `work()`: Handles error-based logic including proxy refresh, not_found, and retry
- Added test for proxy refresh behavior on `ClientHttpProxyError`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped several dependencies to recent stable versions.

* **Refactor**
  * Centralized scraper error handling: failures now surface as explicit error objects that determine retries, requeues, and proxy rotations.
  * Proxy rotation hardened with cooldown and concurrency control to avoid redundant rotations.

* **Tests**
  * Added/updated tests for proxy-error handling, rotation cooldown/coalescing, and adjusted failure-path expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->