### PR TITLE
feat: state machine for scrape task producer state mgmt

### DIFF
--- a/bases/bot_detector/scrape_task_producer/config.py
+++ b/bases/bot_detector/scrape_task_producer/config.py
@@ -4,6 +4,6 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     LIMIT: int = 10_000
     MAX_LAG: int = 100_000
-    NORMAL_DAY_LIMIT = 1
-    POSSIBLE_BAN_DAY_LIMIT = 7
-    CONFIRMED_BAN_DAY_LIMIT = 14
+    NORMAL_DAY_LIMIT: int = 1
+    POSSIBLE_BAN_DAY_LIMIT: int = 7
+    CONFIRMED_BAN_DAY_LIMIT: int = 14

--- a/bases/bot_detector/scrape_task_producer/config.py
+++ b/bases/bot_detector/scrape_task_producer/config.py
@@ -1,0 +1,9 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    LIMIT: int = 10_000
+    MAX_LAG: int = 100_000
+    NORMAL_DAY_LIMIT = 1
+    POSSIBLE_BAN_DAY_LIMIT = 7
+    CONFIRMED_BAN_DAY_LIMIT = 14

--- a/bases/bot_detector/scrape_task_producer/core.py
+++ b/bases/bot_detector/scrape_task_producer/core.py
@@ -17,8 +17,8 @@ from bot_detector.event_queue.lag_probe import LagProbeProtocol
 from bot_detector.event_queue.structs import ToScrapeStruct
 from bot_detector.structs import MetaData, PlayerStruct
 from bot_detector.wide_event import WideEventLogger
-from pydantic_settings import BaseSettings
 
+from .config import Settings
 from .states import (
     ScrapeEvent,
     ScraperCtx,
@@ -30,11 +30,6 @@ from .states import (
 
 logger = logging.getLogger(__name__)
 wide_event = WideEventLogger()
-
-
-class Settings(BaseSettings):
-    LIMIT: int = 10_000
-    MAX_LAG: int = 100_000
 
 
 async def produce_players(

--- a/bases/bot_detector/scrape_task_producer/core.py
+++ b/bases/bot_detector/scrape_task_producer/core.py
@@ -19,7 +19,14 @@ from bot_detector.structs import MetaData, PlayerStruct
 from bot_detector.wide_event import WideEventLogger
 from pydantic_settings import BaseSettings
 
-from .states import ScrapeEvent, ScraperCtx, ScrapeState, _force_log, scraper_sm
+from .states import (
+    ScrapeEvent,
+    ScraperCtx,
+    ScrapeState,
+    _force_log,
+    determine_event,
+    scraper_sm,
+)
 
 logger = logging.getLogger(__name__)
 wide_event = WideEventLogger()
@@ -48,25 +55,6 @@ async def produce_players(
             raise err
 
 
-def determine_event(
-    ctx: ScraperCtx, state: ScrapeState, player_count: int
-) -> ScrapeEvent:
-    if player_count >= ctx.limit:
-        return ScrapeEvent.FETCH_MORE
-
-    day_limits = {
-        ScrapeState.NORMAL: 1,
-        ScrapeState.POSSIBLE_BAN: 7,
-        ScrapeState.CONFIRMED_BAN: 14,
-    }
-
-    threshold = day_limits.get(state)
-    if threshold is not None and ctx.days > threshold:
-        return ScrapeEvent.REDUCE_DAYS
-
-    return ScrapeEvent.NEXT_STEP
-
-
 async def process_players(
     async_session,
     player_repo: PlayerRepo,
@@ -91,10 +79,11 @@ async def process_players(
 
             if state == ScrapeState.DONE:
                 now = datetime.now()
-                sleep_time = max(
-                    int((datetime.combine(now.date(), time.max) - now).total_seconds()),
-                    1,
-                )
+                end_of_today = datetime.combine(now.date(), time.max)
+
+                time_remaining = end_of_today - now
+                # at least sleep for 1 second
+                sleep_time = max(int(time_remaining.total_seconds()), 1)
                 wide_event.add({"done_for_day": {"sleep_seconds": sleep_time}})
                 _force_log()
                 await asyncio.sleep(sleep_time)

--- a/bases/bot_detector/scrape_task_producer/core.py
+++ b/bases/bot_detector/scrape_task_producer/core.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
-from dataclasses import asdict, dataclass
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time
 
 from bot_detector.database import Settings as DBSettings
 from bot_detector.database import get_session_factory
@@ -19,15 +18,11 @@ from bot_detector.event_queue.structs import ToScrapeStruct
 from bot_detector.structs import MetaData, PlayerStruct
 from bot_detector.wide_event import WideEventLogger
 from pydantic_settings import BaseSettings
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from typing_extensions import Literal
+
+from .states import ScrapeEvent, ScraperCtx, ScrapeState, _force_log, scraper_sm
 
 logger = logging.getLogger(__name__)
 wide_event = WideEventLogger()
-
-
-def _force_log() -> None:
-    wide_event.add({"force_log": True})
 
 
 class Settings(BaseSettings):
@@ -35,170 +30,75 @@ class Settings(BaseSettings):
     MAX_LAG: int = 100_000
 
 
-@dataclass
-class FetchParams:
-    step: Literal["normal", "possible_ban", "confirmed_ban"]
-    days: int
-    first_date: date | None = None
-    last_date: date | None = None
-    confirmed_ban: bool = False
-    possible_ban: bool = False
-    player_id: int = 0
-    limit: int = 10_000
-    done: bool = False
-
-    def __post_init__(self):
-        self._update_step_flags()
-        self.update_date(days=self.days, infinity=False)
-
-    def update_date(self, days: int, infinity: bool = False) -> None:
-        self.days = days
-        delta = timedelta(days=365) if infinity else timedelta(days=self.days)
-        self.first_date = date.today() - delta
-        self.last_date = date.today() - timedelta(days=self.days - 1)
-        assert self.first_date < self.last_date
-
-    def _update_step_flags(self) -> None:
-        match self.step:
-            case "normal":
-                self.possible_ban = False
-                self.confirmed_ban = False
-            case "possible_ban":
-                self.possible_ban = True
-                self.confirmed_ban = False
-            case "confirmed_ban":
-                self.possible_ban = True
-                self.confirmed_ban = True
-            case _:
-                raise ValueError(f"Invalid step: {self.step}")
-
-    def set_step(
-        self, step: Literal["normal", "possible_ban", "confirmed_ban"]
-    ) -> None:
-        self.step = step
-        self._update_step_flags()
-
-    def reset_for_new_day(self, max_days: int) -> None:
-        self.set_step("normal")
-        self.update_date(days=max_days, infinity=True)
-        self.player_id = 0
-
-
 async def produce_players(
-    players: list[PlayerStruct],
-    player_queue: QueueProducer[ToScrapeStruct],
+    players: list[PlayerStruct], player_queue: QueueProducer[ToScrapeStruct]
 ):
     if not players:
         return
-
     wide_event.add({"queue_players": {"count": len(players)}})
     metadata = MetaData(version=1, source="scrape_task_producer")
     player_structs = [
-        ToScrapeStruct(metadata=metadata, player_data=player)
-        for player in players
-        if len(player.name) <= 13
+        ToScrapeStruct(metadata=metadata, player_data=p)
+        for p in players
+        if len(p.name) <= 13
     ]
-    if not player_structs:
-        return
-    error = await player_queue.put(player_structs)
-    if isinstance(error, Exception):
-        raise error
+    if player_structs:
+        err = await player_queue.put(player_structs)
+        if isinstance(err, Exception):
+            raise err
 
 
-def _reduce_days(fetch_params: FetchParams) -> FetchParams:
-    wide_event.add({"reduce_days": {"fetch_params": asdict(fetch_params)}})
-    _days = fetch_params.days - 1 if fetch_params.days > 1 else 1
-    fetch_params.update_date(days=_days)
-    fetch_params.player_id = 0
-    return fetch_params
+def determine_event(
+    ctx: ScraperCtx, state: ScrapeState, player_count: int
+) -> ScrapeEvent:
+    if player_count >= ctx.limit:
+        return ScrapeEvent.FETCH_MORE
 
+    day_limits = {
+        ScrapeState.NORMAL: 1,
+        ScrapeState.POSSIBLE_BAN: 7,
+        ScrapeState.CONFIRMED_BAN: 14,
+    }
 
-def determine_fetch_params(
-    fetch_params: FetchParams,
-    players: list[PlayerStruct] | None,
-    max_days: int = 20,
-    max_possible_ban_days: int = 7,
-    max_confirmed_ban_days: int = 14,
-):
-    if players is None:
-        return fetch_params
+    threshold = day_limits.get(state)
+    if threshold is not None and ctx.days > threshold:
+        return ScrapeEvent.REDUCE_DAYS
 
-    fetch_params._update_step_flags()
-
-    if len(players) >= fetch_params.limit:
-        fetch_params.player_id = players[-1].id
-        return fetch_params
-
-    match fetch_params.step:
-        case "normal":
-            if fetch_params.days > 1:
-                return _reduce_days(fetch_params)
-
-            assert fetch_params.days <= 1
-            wide_event.add(
-                {"set_step": {"from": fetch_params.step, "to": "confirmed_ban"}}
-            )
-            _force_log()
-            fetch_params.set_step("possible_ban")
-            fetch_params.update_date(days=max_days, infinity=True)
-            return fetch_params
-
-        case "possible_ban":
-            if fetch_params.days > max_possible_ban_days:
-                return _reduce_days(fetch_params)
-
-            assert fetch_params.days <= max_possible_ban_days
-            wide_event.add(
-                {"set_step": {"from": fetch_params.step, "to": "confirmed_ban"}}
-            )
-            _force_log()
-            fetch_params.set_step("confirmed_ban")
-            fetch_params.update_date(days=max_days, infinity=True)
-            return fetch_params
-
-        case "confirmed_ban":
-            if fetch_params.days > max_confirmed_ban_days:
-                return _reduce_days(fetch_params)
-
-            assert fetch_params.days <= max_confirmed_ban_days
-            wide_event.add(
-                {"set_step": {"from": fetch_params.step, "to": "confirmed_ban"}}
-            )
-            _force_log()
-            fetch_params.set_step("normal")
-            fetch_params.update_date(days=max_days, infinity=True)
-            fetch_params.done = True
-            return fetch_params
+    return ScrapeEvent.NEXT_STEP
 
 
 async def process_players(
-    async_session: async_sessionmaker[AsyncSession],
+    async_session,
     player_repo: PlayerRepo,
-    player_queue: QueueProducer[ToScrapeStruct],
+    player_queue: QueueProducer,
     lag_probe: LagProbeProtocol,
     lag_topic: str,
     lag_group_id: str,
     limit: int = 10,
 ):
-    max_days = 20
-    fp = FetchParams(
-        step="normal",
-        days=max_days,
-        player_id=0,
-        limit=limit,
-    )
-
+    ctx = ScraperCtx(days=20, limit=limit)
+    state = ScrapeState.NORMAL
     last_day = date.today()
 
     while True:
         token = wide_event.set({})
         try:
             lag = await lag_probe.lag(topic=lag_topic, group_id=lag_group_id)
+
             if last_day != date.today():
-                wide_event.add({"new_day_reset": True})
-                _force_log()
                 last_day = date.today()
-                fp.reset_for_new_day(max_days)
+                state = scraper_sm.handle(ctx, state, ScrapeEvent.NEW_DAY)
+
+            if state == ScrapeState.DONE:
+                now = datetime.now()
+                sleep_time = max(
+                    int((datetime.combine(now.date(), time.max) - now).total_seconds()),
+                    1,
+                )
+                wide_event.add({"done_for_day": {"sleep_seconds": sleep_time}})
+                _force_log()
+                await asyncio.sleep(sleep_time)
+                continue
 
             if lag >= Settings().MAX_LAG:
                 wide_event.add({"lag_throttle": {"lag": lag}})
@@ -206,104 +106,85 @@ async def process_players(
                 await asyncio.sleep(10)
                 continue
 
-            fp_dict = asdict(fp)
-            fp_dict.update(
-                {"first_date": str(fp.first_date), "last_date": str(fp.last_date)}
+            wide_event.add(
+                {
+                    "fetch_params": {
+                        "step": state.name,
+                        "days": ctx.days,
+                        "first_date": str(ctx.first_date),
+                        "last_date": str(ctx.last_date),
+                    }
+                }
             )
-            wide_event.add({"fetch_params": fp_dict})
 
             async with async_session() as session:
                 players = await player_repo.select_player(
                     async_session=session,
-                    player_id=fp.player_id,
-                    possible_ban=fp.possible_ban,
-                    confirmed_ban=fp.confirmed_ban,
-                    or_none=fp.step == "normal",
-                    first_date=fp.first_date,
-                    last_date=fp.last_date,
-                    limit=fp.limit,
+                    player_id=ctx.player_id,
+                    possible_ban=ctx.possible_ban,
+                    confirmed_ban=ctx.confirmed_ban,
+                    or_none=state == ScrapeState.NORMAL,
+                    first_date=ctx.first_date,
+                    last_date=ctx.last_date,
+                    limit=ctx.limit,
                 )
 
-            await produce_players(players=players, player_queue=player_queue)
+            await produce_players(players, player_queue)
 
-            fp = determine_fetch_params(
-                fetch_params=fp,
-                players=players,
-                max_days=max_days,
-            )
+            if players:
+                ctx.last_fetched_id = players[-1].id
 
-            if fp.done:
-                fp.done = False
-                now = datetime.now()
-                end_of_today = datetime.combine(now.date(), time.max)
+            event = determine_event(ctx, state, len(players) if players else 0)
+            state = scraper_sm.handle(ctx, state, event)
 
-                time_remaining = end_of_today - now
-                sleep_time = int(time_remaining.total_seconds())
-                sleep_time = max(sleep_time, 1)  # Ensure at least 1 second sleep
-                wide_event.add({"done_for_day": {"sleep_seconds": sleep_time}})
-                _force_log()
-                await asyncio.sleep(sleep_time)
         except Exception as exc:
             wide_event.add({"error": {"message": str(exc)}})
             raise
         finally:
             final_ctx = wide_event.get()
-            force_log = bool(final_ctx.pop("force_log", False))
             if "error" in final_ctx:
                 logger.error(final_ctx)
-            elif force_log:
-                final_ctx.update({"log_reason": "force"})
+            elif final_ctx.pop("force_log", False):
+                final_ctx["log_reason"] = "force"
                 logger.info(final_ctx)
             elif wide_event.sample():
-                final_ctx.update({"log_reason": "sample"})
+                final_ctx["log_reason"] = "sample"
                 logger.info(final_ctx)
             wide_event.reset(token)
 
 
 async def main():
     async_session, async_engine = get_session_factory(SETTINGS=DBSettings())
-
-    bootstrap_servers = KafkaSettings().bootstrap_servers
-    lag_topic = "players.to_scrape"
-    lag_group_id = "scraper"
-
-    def partition_key_fn(msg: ToScrapeStruct) -> str:
-        return str(msg.player_data.id % 10)
-
-    player_queue = QueueFactory.create_queue(
-        model=ToScrapeStruct,
-        queue_type="producer",
-        backend_type="kafka",
-        config=KafkaConfig(
-            topic=lag_topic,
-            bootstrap_servers=bootstrap_servers,
-            producer=True,
-            consumer=False,
-            producer_config=KafkaProducerConfig(partition_key_fn=partition_key_fn),
+    cfg = KafkaConfig(
+        topic="players.to_scrape",
+        bootstrap_servers=KafkaSettings().bootstrap_servers,
+        producer=True,
+        consumer=False,
+        producer_config=KafkaProducerConfig(
+            partition_key_fn=lambda m: str(m.player_data.id % 10)
         ),
     )
+    player_queue = QueueFactory.create_queue(ToScrapeStruct, "producer", "kafka", cfg)
     if isinstance(player_queue, Exception):
         raise player_queue
 
-    assert isinstance(player_queue, QueueProducer)
-
-    lag_probe = KafkaLagProbe(bootstrap_servers)
-
+    lag_probe = KafkaLagProbe(KafkaSettings().bootstrap_servers)
     if isinstance(lag_probe, Exception):
         raise lag_probe
 
     await player_queue.start()
     await lag_probe.start()
 
+    assert isinstance(player_queue, QueueProducer)
     try:
         await process_players(
-            async_session=async_session,
-            player_repo=PlayerRepo(),
-            player_queue=player_queue,
-            lag_probe=lag_probe,
-            lag_topic=lag_topic,
-            lag_group_id=lag_group_id,
-            limit=Settings().LIMIT,
+            async_session,
+            PlayerRepo(),
+            player_queue,
+            lag_probe,
+            "players.to_scrape",
+            "scraper",
+            Settings().LIMIT,
         )
     finally:
         await async_engine.dispose()
@@ -311,13 +192,5 @@ async def main():
         await player_queue.stop()
 
 
-async def run_async():
-    await main()
-
-
-def run():
-    asyncio.run(run_async())
-
-
 if __name__ == "__main__":
-    run()
+    asyncio.run(main())

--- a/bases/bot_detector/scrape_task_producer/sm.py
+++ b/bases/bot_detector/scrape_task_producer/sm.py
@@ -2,9 +2,9 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Callable, Generic, Iterable, TypeVar
 
-S = TypeVar("S", bound=Enum)
-E = TypeVar("E", bound=Enum)
-C = TypeVar("C")
+S = TypeVar("S", bound=Enum)  # state
+E = TypeVar("E", bound=Enum)  # event
+C = TypeVar("C")  # context
 
 Action = Callable[[C], None]
 
@@ -28,12 +28,13 @@ class StateMachine(Generic[S, E, C]):
         except KeyError as e:
             raise InvalidTransition(f"Cannot {event.name} when {state.name}") from e
 
+    # see: .states.py for the transition definitions
     def handle(self, ctx: C, state: S, event: E) -> S:
         next_state, action = self.next_transition(state, event)
         action(ctx)
         return next_state
 
-    def transition(self, from_state: S | Iterable[S], event: E, to_state: S):
+    def transition(self, from_state: S | Iterable[S], event: E, to_state: S | None):
         if not isinstance(from_state, Iterable):
             states = (from_state,)
         else:
@@ -41,7 +42,8 @@ class StateMachine(Generic[S, E, C]):
 
         def decorator(func: Action) -> Action:
             for s in states:
-                self.add_transition(s, event, to_state, func)
+                _to = s if to_state is None else to_state
+                self.add_transition(s, event, _to, func)
             return func
 
         return decorator

--- a/bases/bot_detector/scrape_task_producer/sm.py
+++ b/bases/bot_detector/scrape_task_producer/sm.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Generic, Iterable, TypeVar
+
+S = TypeVar("S", bound=Enum)
+E = TypeVar("E", bound=Enum)
+C = TypeVar("C")
+
+Action = Callable[[C], None]
+
+
+class InvalidTransition(Exception):
+    pass
+
+
+@dataclass
+class StateMachine(Generic[S, E, C]):
+    transitions: dict[tuple[S, E], tuple[S, Action]] = field(default_factory=dict)
+
+    def add_transition(
+        self, from_state: S, event: E, to_state: S, func: Action
+    ) -> None:
+        self.transitions[(from_state, event)] = (to_state, func)
+
+    def next_transition(self, state: S, event: E) -> tuple[S, Action]:
+        try:
+            return self.transitions[(state, event)]
+        except KeyError as e:
+            raise InvalidTransition(f"Cannot {event.name} when {state.name}") from e
+
+    def handle(self, ctx: C, state: S, event: E) -> S:
+        next_state, action = self.next_transition(state, event)
+        action(ctx)
+        return next_state
+
+    def transition(self, from_state: S | Iterable[S], event: E, to_state: S):
+        if not isinstance(from_state, Iterable):
+            states = (from_state,)
+        else:
+            states = from_state
+
+        def decorator(func: Action) -> Action:
+            for s in states:
+                self.add_transition(s, event, to_state, func)
+            return func
+
+        return decorator

--- a/bases/bot_detector/scrape_task_producer/states.py
+++ b/bases/bot_detector/scrape_task_producer/states.py
@@ -10,24 +10,22 @@ wide_event = WideEventLogger()
 
 scraper_sm = StateMachine[ScrapeState, ScrapeEvent, ScraperCtx]()
 ALL = (ScrapeState.NORMAL, ScrapeState.POSSIBLE_BAN, ScrapeState.CONFIRMED_BAN)
+ALL_DONE = (
+    ScrapeState.NORMAL,
+    ScrapeState.POSSIBLE_BAN,
+    ScrapeState.CONFIRMED_BAN,
+    ScrapeState.DONE,
+)
 
 
 # fmt: off
-@scraper_sm.transition(from_state=ALL, event=ScrapeEvent.FETCH_MORE, to_state=ScrapeState.NORMAL)
-@scraper_sm.transition(from_state=ALL, event=ScrapeEvent.FETCH_MORE, to_state=ScrapeState.POSSIBLE_BAN)
-@scraper_sm.transition(from_state=ALL, event=ScrapeEvent.FETCH_MORE,to_state=ScrapeState.CONFIRMED_BAN)
+@scraper_sm.transition(from_state=ALL, event=ScrapeEvent.FETCH_MORE, to_state=None)
 # fmt: on
 def fetch_more(ctx: ScraperCtx) -> None:
-    # Hack to keep same state: manually set to_state per from_state.
-    # Decorator maps explicitly above, but engine needs exact to_state.
-    # Alternative: return state from action.
-    # Here, engine updates state. We just update context.
     ctx.player_id = ctx.last_fetched_id
 
 # fmt: off
-@scraper_sm.transition(from_state=ScrapeState.NORMAL, event=ScrapeEvent.REDUCE_DAYS, to_state=ScrapeState.NORMAL)
-@scraper_sm.transition(from_state=ScrapeState.POSSIBLE_BAN, event=ScrapeEvent.REDUCE_DAYS, to_state=ScrapeState.POSSIBLE_BAN)
-@scraper_sm.transition(from_state=ScrapeState.CONFIRMED_BAN, event=ScrapeEvent.REDUCE_DAYS, to_state=ScrapeState.CONFIRMED_BAN)
+@scraper_sm.transition(from_state=ALL, event=ScrapeEvent.REDUCE_DAYS, to_state=None)
 # fmt: on
 def reduce_days(ctx: ScraperCtx) -> None:
     wide_event.add({"reduce_days": {"fetch_params": asdict(ctx)}})
@@ -69,7 +67,7 @@ def to_done(ctx: ScraperCtx) -> None:
     ctx.update_date(days=20, infinity=True)
 
 # fmt: off
-@scraper_sm.transition((ScrapeState.DONE, ScrapeState.NORMAL), ScrapeEvent.NEW_DAY, ScrapeState.NORMAL)
+@scraper_sm.transition(ALL_DONE, ScrapeEvent.NEW_DAY, ScrapeState.NORMAL)
 # fmt: on
 def reset_new_day(ctx: ScraperCtx) -> None:
     wide_event.add({"new_day_reset": True})
@@ -78,3 +76,21 @@ def reset_new_day(ctx: ScraperCtx) -> None:
     ctx.confirmed_ban = False
     ctx.player_id = 0
     ctx.update_date(days=20, infinity=True)
+
+def determine_event(
+    ctx: ScraperCtx, state: ScrapeState, player_count: int
+) -> ScrapeEvent:
+    if player_count >= ctx.limit:
+        return ScrapeEvent.FETCH_MORE
+
+    day_limits = {
+        ScrapeState.NORMAL: 1,
+        ScrapeState.POSSIBLE_BAN: 7,
+        ScrapeState.CONFIRMED_BAN: 14,
+    }
+
+    threshold = day_limits.get(state)
+    if threshold is not None and ctx.days > threshold:
+        return ScrapeEvent.REDUCE_DAYS
+
+    return ScrapeEvent.NEXT_STEP

--- a/bases/bot_detector/scrape_task_producer/states.py
+++ b/bases/bot_detector/scrape_task_producer/states.py
@@ -1,0 +1,80 @@
+from dataclasses import asdict
+
+from bot_detector.scrape_task_producer.sm import StateMachine
+from bot_detector.wide_event import WideEventLogger
+
+from .structs import ScrapeEvent, ScraperCtx, ScrapeState
+
+wide_event = WideEventLogger()
+
+
+scraper_sm = StateMachine[ScrapeState, ScrapeEvent, ScraperCtx]()
+ALL = (ScrapeState.NORMAL, ScrapeState.POSSIBLE_BAN, ScrapeState.CONFIRMED_BAN)
+
+
+# fmt: off
+@scraper_sm.transition(from_state=ALL, event=ScrapeEvent.FETCH_MORE, to_state=ScrapeState.NORMAL)
+@scraper_sm.transition(from_state=ALL, event=ScrapeEvent.FETCH_MORE, to_state=ScrapeState.POSSIBLE_BAN)
+@scraper_sm.transition(from_state=ALL, event=ScrapeEvent.FETCH_MORE,to_state=ScrapeState.CONFIRMED_BAN)
+# fmt: on
+def fetch_more(ctx: ScraperCtx) -> None:
+    # Hack to keep same state: manually set to_state per from_state.
+    # Decorator maps explicitly above, but engine needs exact to_state.
+    # Alternative: return state from action.
+    # Here, engine updates state. We just update context.
+    ctx.player_id = ctx.last_fetched_id
+
+# fmt: off
+@scraper_sm.transition(from_state=ScrapeState.NORMAL, event=ScrapeEvent.REDUCE_DAYS, to_state=ScrapeState.NORMAL)
+@scraper_sm.transition(from_state=ScrapeState.POSSIBLE_BAN, event=ScrapeEvent.REDUCE_DAYS, to_state=ScrapeState.POSSIBLE_BAN)
+@scraper_sm.transition(from_state=ScrapeState.CONFIRMED_BAN, event=ScrapeEvent.REDUCE_DAYS, to_state=ScrapeState.CONFIRMED_BAN)
+# fmt: on
+def reduce_days(ctx: ScraperCtx) -> None:
+    wide_event.add({"reduce_days": {"fetch_params": asdict(ctx)}})
+    _days = ctx.days - 1 if ctx.days > 1 else 1
+    ctx.update_date(days=_days, infinity=False)
+    ctx.player_id = 0
+
+def _force_log() -> None:
+    wide_event.add({"force_log": True})
+
+# fmt: off
+@scraper_sm.transition(ScrapeState.NORMAL, ScrapeEvent.NEXT_STEP, ScrapeState.POSSIBLE_BAN)
+# fmt: on
+def to_possible_ban(ctx: ScraperCtx) -> None:
+    wide_event.add({"set_step": {"from": "normal", "to": "possible_ban"}})
+    _force_log()
+    ctx.possible_ban = True
+    ctx.confirmed_ban = False
+    ctx.update_date(days=20, infinity=True)
+
+# fmt: off
+@scraper_sm.transition(ScrapeState.POSSIBLE_BAN, ScrapeEvent.NEXT_STEP, ScrapeState.CONFIRMED_BAN)
+# fmt: on
+def to_confirmed_ban(ctx: ScraperCtx) -> None:
+    wide_event.add({"set_step": {"from": "possible_ban", "to": "confirmed_ban"}})
+    _force_log()
+    ctx.possible_ban = True
+    ctx.confirmed_ban = True
+    ctx.update_date(days=20, infinity=True)
+
+# fmt: off
+@scraper_sm.transition(ScrapeState.CONFIRMED_BAN, ScrapeEvent.NEXT_STEP, ScrapeState.DONE)
+# fmt: on
+def to_done(ctx: ScraperCtx) -> None:
+    wide_event.add({"set_step": {"from": "confirmed_ban", "to": "done"}})
+    _force_log()
+    ctx.possible_ban = False
+    ctx.confirmed_ban = False
+    ctx.update_date(days=20, infinity=True)
+
+# fmt: off
+@scraper_sm.transition((ScrapeState.DONE, ScrapeState.NORMAL), ScrapeEvent.NEW_DAY, ScrapeState.NORMAL)
+# fmt: on
+def reset_new_day(ctx: ScraperCtx) -> None:
+    wide_event.add({"new_day_reset": True})
+    _force_log()
+    ctx.possible_ban = False
+    ctx.confirmed_ban = False
+    ctx.player_id = 0
+    ctx.update_date(days=20, infinity=True)

--- a/bases/bot_detector/scrape_task_producer/states.py
+++ b/bases/bot_detector/scrape_task_producer/states.py
@@ -3,6 +3,7 @@ from dataclasses import asdict
 from bot_detector.scrape_task_producer.sm import StateMachine
 from bot_detector.wide_event import WideEventLogger
 
+from .config import Settings
 from .structs import ScrapeEvent, ScraperCtx, ScrapeState
 
 wide_event = WideEventLogger()
@@ -84,9 +85,9 @@ def determine_event(
         return ScrapeEvent.FETCH_MORE
 
     day_limits = {
-        ScrapeState.NORMAL: 1,
-        ScrapeState.POSSIBLE_BAN: 7,
-        ScrapeState.CONFIRMED_BAN: 14,
+        ScrapeState.NORMAL: Settings().NORMAL_DAY_LIMIT,
+        ScrapeState.POSSIBLE_BAN: Settings().POSSIBLE_BAN_DAY_LIMIT,
+        ScrapeState.CONFIRMED_BAN: Settings().CONFIRMED_BAN_DAY_LIMIT,
     }
 
     threshold = day_limits.get(state)

--- a/bases/bot_detector/scrape_task_producer/structs.py
+++ b/bases/bot_detector/scrape_task_producer/structs.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from datetime import date, timedelta
+from enum import Enum, auto
+
+
+class ScrapeState(Enum):
+    NORMAL = auto()
+    POSSIBLE_BAN = auto()
+    CONFIRMED_BAN = auto()
+    DONE = auto()
+
+
+class ScrapeEvent(Enum):
+    FETCH_MORE = auto()
+    REDUCE_DAYS = auto()
+    NEXT_STEP = auto()
+    NEW_DAY = auto()
+
+
+@dataclass
+class ScraperCtx:
+    days: int
+    limit: int
+    first_date: date | None = None
+    last_date: date | None = None
+    confirmed_ban: bool = False
+    possible_ban: bool = False
+    player_id: int = 0
+    last_fetched_id: int = 0
+
+    def __post_init__(self):
+        self.update_date(self.days, infinity=True)
+
+    def update_date(self, days: int, infinity: bool = False) -> None:
+        self.days = days
+        delta = timedelta(days=365) if infinity else timedelta(days=self.days)
+        self.first_date = date.today() - delta
+        self.last_date = date.today() - timedelta(days=self.days - 1)

--- a/test/bases/bot_detector/scrape_task_producer/test_core.py
+++ b/test/bases/bot_detector/scrape_task_producer/test_core.py
@@ -1,4 +1,6 @@
+import pytest
 from bot_detector.scrape_task_producer.core import determine_event
+from bot_detector.scrape_task_producer.sm import InvalidTransition
 from bot_detector.scrape_task_producer.states import (
     ScrapeEvent,
     ScraperCtx,
@@ -128,3 +130,17 @@ def test_determine_event_next_step_possible_ban():
     # Days <= 7 threshold for POSSIBLE_BAN
     event = determine_event(ctx, ScrapeState.POSSIBLE_BAN, player_count=0)
     assert event == ScrapeEvent.NEXT_STEP
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        ScrapeEvent.FETCH_MORE,
+        ScrapeEvent.REDUCE_DAYS,
+        ScrapeEvent.NEXT_STEP,
+    ],
+)
+def test_invalid_transition_from_done(event):
+    ctx = make_ctx(state=ScrapeState.DONE)
+    with pytest.raises(InvalidTransition):
+        scraper_sm.handle(ctx, ScrapeState.DONE, event)

--- a/test/bases/bot_detector/scrape_task_producer/test_core.py
+++ b/test/bases/bot_detector/scrape_task_producer/test_core.py
@@ -1,123 +1,130 @@
-import datetime
-
-import pytest
-from bot_detector.scrape_task_producer.core import FetchParams, determine_fetch_params
-from bot_detector.structs import PlayerStruct
-
-
-def make_fetch_params(**overrides) -> FetchParams:
-    """Helper: start from sane defaults, apply any overrides."""
-    params = FetchParams(
-        days=overrides.get("days", 7),
-        confirmed_ban=overrides.get("confirmed_ban", False),
-        possible_ban=overrides.get("possible_ban", False),
-        player_id=overrides.get("player_id", 0),
-        limit=overrides.get("limit", 1),
-        step=overrides.get("step", "normal"),
-        done=overrides.get("done", False),
-    )
-    return params
+from bot_detector.scrape_task_producer.core import determine_event
+from bot_detector.scrape_task_producer.states import (
+    ScrapeEvent,
+    ScraperCtx,
+    ScrapeState,
+    scraper_sm,
+)
 
 
-def make_player(id: int = 1) -> PlayerStruct:
-    """Minimal player factory with unique id."""
-    now = datetime.datetime(2025, 1, 1, 12, 0, 0)
-    return PlayerStruct(
-        id=id,
-        name=f"Player{id}",
-        created_at=now,
-        updated_at=now,
-        possible_ban=False,
-        confirmed_ban=False,
-        confirmed_player=True,
-        label_id=1,
-        label_jagex=2,
-    )
+def make_ctx(days=20, limit=10, state=ScrapeState.NORMAL) -> ScraperCtx:
+    ctx = ScraperCtx(days=days, limit=limit)
+    if state == ScrapeState.POSSIBLE_BAN:
+        ctx.possible_ban = True
+    elif state == ScrapeState.CONFIRMED_BAN:
+        ctx.possible_ban = True
+        ctx.confirmed_ban = True
+    return ctx
 
 
-def test_returns_same_object_when_players_is_none():
-    fp = make_fetch_params(
-        days=3, possible_ban=True, confirmed_ban=True, player_id=5, limit=2
-    )
-    result = determine_fetch_params(fp, players=None)
-    assert result is fp  # no mutation, same instance
+def test_fetch_more_updates_player_id_keeps_state():
+    ctx = make_ctx()
+    ctx.last_fetched_id = 42
+
+    new_state = scraper_sm.handle(ctx, ScrapeState.NORMAL, ScrapeEvent.FETCH_MORE)
+
+    assert new_state == ScrapeState.NORMAL
+    assert ctx.player_id == 42
+    assert ctx.days == 20
 
 
-def test_sets_player_id_to_last_when_full_page_of_results():
-    players = [make_player(42)]
-    fp = make_fetch_params(limit=1)
-    result = determine_fetch_params(fp, players=players)
-    assert result.player_id == 42
-    # days and flags unchanged
-    assert result.days == 7
-    assert not result.possible_ban and not result.confirmed_ban
+def test_reduce_days_decrements_days_resets_player_id():
+    ctx = make_ctx(days=5)
+    ctx.player_id = 99
+
+    new_state = scraper_sm.handle(ctx, ScrapeState.NORMAL, ScrapeEvent.REDUCE_DAYS)
+
+    assert new_state == ScrapeState.NORMAL
+    assert ctx.days == 4
+    assert ctx.player_id == 0
 
 
-def test_resets_possible_ban_if_confirmed_ban_without_possible():
-    # confirmed_ban=True but possible_ban=False → possible_ban forced True
-    fp = make_fetch_params(confirmed_ban=True, possible_ban=False, step="confirmed_ban")
-    result = determine_fetch_params(fp, players=[make_player()])
-    assert result.possible_ban is True
+def test_reduce_days_floors_at_one():
+    ctx = make_ctx(days=1)
+
+    scraper_sm.handle(ctx, ScrapeState.NORMAL, ScrapeEvent.REDUCE_DAYS)
+
+    assert ctx.days == 1
 
 
-@pytest.mark.parametrize("initial_days", [7, 5, 3])
-def test_decrements_days_when_no_players_and_no_bans(initial_days):
-    fp = make_fetch_params(days=initial_days, possible_ban=False, confirmed_ban=False)
-    result = determine_fetch_params(fp, players=[])
-    assert result.days == initial_days - 1
-    assert result.player_id == 0
+def test_next_step_normal_to_possible_ban():
+    ctx = make_ctx(days=1)
+
+    new_state = scraper_sm.handle(ctx, ScrapeState.NORMAL, ScrapeEvent.NEXT_STEP)
+
+    assert new_state == ScrapeState.POSSIBLE_BAN
+    assert ctx.possible_ban is True
+    assert ctx.confirmed_ban is False
+    assert ctx.days == 20  # Resets to max_days
 
 
-def test_decrements_days_when_no_players_and_possible_only_above_max():
-    # default max_possible_ban_days=2, so days=5>2 → decrement
-    fp = make_fetch_params(days=5, possible_ban=True, confirmed_ban=False)
-    result = determine_fetch_params(fp, players=[])
-    assert result.days == 4
+def test_next_step_possible_ban_to_confirmed_ban():
+    ctx = make_ctx(days=7, state=ScrapeState.POSSIBLE_BAN)
+
+    new_state = scraper_sm.handle(ctx, ScrapeState.POSSIBLE_BAN, ScrapeEvent.NEXT_STEP)
+
+    assert new_state == ScrapeState.CONFIRMED_BAN
+    assert ctx.possible_ban is True
+    assert ctx.confirmed_ban is True
+    assert ctx.days == 20
 
 
-def test_decrements_days_when_no_players_and_both_bans_above_max():
-    # default max_confirmed_ban_days=7, so days=8>7 → decrement
-    fp = make_fetch_params(days=8, possible_ban=True, confirmed_ban=True)
-    result = determine_fetch_params(fp, players=[])
-    assert result.days == 7
+def test_next_step_confirmed_ban_to_done():
+    ctx = make_ctx(days=14, state=ScrapeState.CONFIRMED_BAN)
+
+    new_state = scraper_sm.handle(ctx, ScrapeState.CONFIRMED_BAN, ScrapeEvent.NEXT_STEP)
+
+    assert new_state == ScrapeState.DONE
+    assert ctx.possible_ban is False
+    assert ctx.confirmed_ban is False
+    assert ctx.days == 20
 
 
-def test_switches_to_possible_ban_when_days_at_one_and_no_bans():
-    fp = make_fetch_params(
-        days=1,
-        possible_ban=False,
-        confirmed_ban=False,
-        step="normal",
-    )
-    result = determine_fetch_params(fp, players=[], max_days=10)
-    # days resets to max_days, possible_ban flips on
-    assert result.days == 10
-    assert result.step == "possible_ban"
+def test_new_day_resets_to_normal():
+    ctx = make_ctx(days=5, state=ScrapeState.DONE)
+    ctx.player_id = 123
+
+    new_state = scraper_sm.handle(ctx, ScrapeState.DONE, ScrapeEvent.NEW_DAY)
+
+    assert new_state == ScrapeState.NORMAL
+    assert ctx.player_id == 0
+    assert ctx.days == 20
+    assert ctx.possible_ban is False
 
 
-def test_advances_to_confirmed_ban_when_possible_cycle_exhausted():
-    # days <= max_possible_ban_days (default 2), possible_ban=True, confirmed_ban=False
-    fp = make_fetch_params(
-        days=2,
-        step="possible_ban",
-    )
-    result = determine_fetch_params(fp, players=[], max_days=9)
-    assert result.days == 9
-    assert result.step == "confirmed_ban"
+# --- determine_event logic tests ---
 
 
-def test_full_reset_after_confirmed_cycle_exhausted():
-    # days <= max_confirmed_ban_days (default 7), both bans True
-    fp = make_fetch_params(
-        days=7,
-        step="confirmed_ban",
-    )
-    result = determine_fetch_params(
-        fp,
-        players=[],
-        max_days=11,
-        max_possible_ban_days=3,
-        max_confirmed_ban_days=7,
-    )
-    assert result.step == "normal"
-    assert result.days == 11
+def test_determine_event_fetch_more():
+    ctx = make_ctx(limit=10)
+    # 10 players returned, hit limit
+    event = determine_event(ctx, ScrapeState.NORMAL, player_count=10)
+    assert event == ScrapeEvent.FETCH_MORE
+
+
+def test_determine_event_reduce_days_normal():
+    ctx = make_ctx(days=2, limit=10)
+    # 5 players returned, under limit. Days > 1 threshold for NORMAL
+    event = determine_event(ctx, ScrapeState.NORMAL, player_count=5)
+    assert event == ScrapeEvent.REDUCE_DAYS
+
+
+def test_determine_event_next_step_normal():
+    ctx = make_ctx(days=1, limit=10)
+    # Days <= 1 threshold for NORMAL
+    event = determine_event(ctx, ScrapeState.NORMAL, player_count=5)
+    assert event == ScrapeEvent.NEXT_STEP
+
+
+def test_determine_event_reduce_days_possible_ban():
+    ctx = make_ctx(days=8, limit=10)
+    # Days > 7 threshold for POSSIBLE_BAN
+    event = determine_event(ctx, ScrapeState.POSSIBLE_BAN, player_count=0)
+    assert event == ScrapeEvent.REDUCE_DAYS
+
+
+def test_determine_event_next_step_possible_ban():
+    ctx = make_ctx(days=7, limit=10)
+    # Days <= 7 threshold for POSSIBLE_BAN
+    event = determine_event(ctx, ScrapeState.POSSIBLE_BAN, player_count=0)
+    assert event == ScrapeEvent.NEXT_STEP


### PR DESCRIPTION
 replaces imperative FetchParams mutation with generic state machine. Good separation: sm.py (generic engine), structs.py (enums/context), states.py (transition declarations), core.py (orchestration). ~120 lines cut from core.
 ## Summary

Refactor scrape task producer state management from mutable `FetchParams` to an explicit state machine pattern.

### Changes

- **Add generic state machine** (`sm.py`): `StateMachine[S, E, C]` with enum states/events, context object, decorator-based transition registration.
- **Extract domain types** (`structs.py`): `ScrapeState` enum (NORMAL → POSSIBLE_BAN → CONFIRMED_BAN → DONE), `ScrapeEvent` enum (FETCH_MORE, REDUCE_DAYS, NEXT_STEP, NEW_DAY), `ScraperCtx` dataclass replacing `FetchParams`.
- **Declare transitions** (`states.py`): All state transitions and side effects via `@scraper_sm.transition` decorators.
- **Simplify core** (`core.py`): Replace `determine_fetch_params` (mutation) with `determine_event` (pure) + `scraper_sm.handle` (transition). Remove `run_async`/`run` wrappers, inline `main()` setup.
- **Rewrite tests**: Test state transitions and event determination independently.

### State flow
```
NORMAL → POSSIBLE_BAN → CONFIRMED_BAN → DONE
  ↑                                    |
  └──────────── NEW_DAY ───────────────┘
```

Each state narrows the date window (REDUCE_DAYS) until exhausted, then advances (NEXT_STEP). FETCH_MORE pages via cursor.

### Notes

`fetch_more` uses three decorators (one per state → self) as a workaround for missing self-transition concept in the generic SM. Consider adding `transition_to_self` or allowing `to_state=None` to mean "stay."