### PR TITLE
refactor: clean up discord repository return style and remove redundant commits

### DIFF
--- a/components/bot_detector/database/discord/interface.py
+++ b/components/bot_detector/database/discord/interface.py
@@ -30,6 +30,7 @@ class DiscordVerificationInterface(ABC):
         discord_id: str,
         player_id: int,
         code: str,
+        auto_commit: bool = True,
     ) -> None:
         pass
 
@@ -40,6 +41,7 @@ class DiscordVerificationInterface(ABC):
         discord_id: str,
         player_id: int,
         verified_status: int,
+        auto_commit: bool = True,
     ) -> bool:
         pass
 
@@ -50,5 +52,6 @@ class DiscordVerificationInterface(ABC):
         discord_id: str,
         player_id: int,
         is_primary: bool,
+        auto_commit: bool = True,
     ) -> bool:
         pass

--- a/components/bot_detector/database/discord/interface.py
+++ b/components/bot_detector/database/discord/interface.py
@@ -30,7 +30,7 @@ class DiscordVerificationInterface(ABC):
         discord_id: str,
         player_id: int,
         code: str,
-    ) -> DiscordVerificationTableStruct:
+    ) -> None:
         pass
 
     @abstractmethod

--- a/components/bot_detector/database/discord/repository.py
+++ b/components/bot_detector/database/discord/repository.py
@@ -36,7 +36,8 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
 
         async with async_session.begin():
             result = await async_session.execute(query)
-            return result.scalar_one_or_none()
+            row = result.scalar_one_or_none()
+        return row
 
     async def get_linked_accounts(
         self,
@@ -52,7 +53,8 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
 
         async with async_session.begin():
             result = await async_session.execute(query)
-            return list(result.scalars().all())
+            rows = list(result.scalars().all())
+        return rows
 
     async def create_verification(
         self,
@@ -72,16 +74,15 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
 
         async with async_session.begin():
             await async_session.execute(query)
-            await async_session.commit()
 
-            return DiscordVerificationTableStruct(
-                Discord_id=discord_id,
-                Player_id=player_id,
-                Code=code,
-                primary_rsn=0,
-                verified_status=0,
-                token_used=0,
-            )
+        return DiscordVerificationTableStruct(
+            Discord_id=discord_id,
+            Player_id=player_id,
+            Code=code,
+            primary_rsn=0,
+            verified_status=0,
+            token_used=0,
+        )
 
     async def update_verification_status(
         self,
@@ -102,9 +103,8 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
 
         async with async_session.begin():
             result = await async_session.execute(query)
-            await async_session.commit()
-
-            return result.rowcount > 0  # type: ignore[attr-defined]
+            updated = result.rowcount > 0
+        return updated  # type: ignore[attr-defined]
 
     async def set_primary_rsn(
         self,
@@ -129,6 +129,5 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
         async with async_session.begin():
             await async_session.execute(clear_query)
             result = await async_session.execute(set_query)
-            await async_session.commit()
-
-            return result.rowcount > 0  # type: ignore[attr-defined]
+            updated = result.rowcount > 0
+        return updated  # type: ignore[attr-defined]

--- a/components/bot_detector/database/discord/repository.py
+++ b/components/bot_detector/database/discord/repository.py
@@ -62,7 +62,7 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
         discord_id: str,
         player_id: int,
         code: str,
-    ) -> DiscordVerificationTableStruct:
+    ) -> None:
         query = insert(DiscordVerificationTableStruct).values(
             Discord_id=discord_id,
             Player_id=player_id,
@@ -72,17 +72,8 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
             token_used=0,
         )
 
-        async with async_session.begin():
-            await async_session.execute(query)
-
-        return DiscordVerificationTableStruct(
-            Discord_id=discord_id,
-            Player_id=player_id,
-            Code=code,
-            primary_rsn=0,
-            verified_status=0,
-            token_used=0,
-        )
+        await async_session.execute(query)
+        await async_session.commit()
 
     async def update_verification_status(
         self,
@@ -101,10 +92,9 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
             )
         )
 
-        async with async_session.begin():
-            result = await async_session.execute(query)
-            updated = result.rowcount > 0
-        return updated  # type: ignore[attr-defined]
+        result = await async_session.execute(query)
+        await async_session.commit()
+        return result.rowcount > 0  # type: ignore[attr-defined]
 
     async def set_primary_rsn(
         self,
@@ -126,8 +116,7 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
             .values(primary_rsn=1 if is_primary else 0, updated_at=datetime.now())
         )
 
-        async with async_session.begin():
-            await async_session.execute(clear_query)
-            result = await async_session.execute(set_query)
-            updated = result.rowcount > 0
-        return updated  # type: ignore[attr-defined]
+        await async_session.execute(clear_query)
+        result = await async_session.execute(set_query)
+        await async_session.commit()
+        return result.rowcount > 0  # type: ignore[attr-defined]

--- a/components/bot_detector/database/discord/repository.py
+++ b/components/bot_detector/database/discord/repository.py
@@ -62,6 +62,7 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
         discord_id: str,
         player_id: int,
         code: str,
+        auto_commit: bool = True,
     ) -> None:
         query = insert(DiscordVerificationTableStruct).values(
             Discord_id=discord_id,
@@ -73,7 +74,8 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
         )
 
         await async_session.execute(query)
-        await async_session.commit()
+        if auto_commit:
+            await async_session.commit()
 
     async def update_verification_status(
         self,
@@ -81,6 +83,7 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
         discord_id: str,
         player_id: int,
         verified_status: int,
+        auto_commit: bool = True,
     ) -> bool:
         query = (
             update(DiscordVerificationTableStruct)
@@ -93,7 +96,8 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
         )
 
         result = await async_session.execute(query)
-        await async_session.commit()
+        if auto_commit:
+            await async_session.commit()
         return result.rowcount > 0  # type: ignore[attr-defined]
 
     async def set_primary_rsn(
@@ -102,6 +106,7 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
         discord_id: str,
         player_id: int,
         is_primary: bool,
+        auto_commit: bool = True,
     ) -> bool:
         clear_query = (
             update(DiscordVerificationTableStruct)
@@ -118,5 +123,6 @@ class DiscordVerificationRepo(DiscordVerificationInterface):
 
         await async_session.execute(clear_query)
         result = await async_session.execute(set_query)
-        await async_session.commit()
+        if auto_commit:
+            await async_session.commit()
         return result.rowcount > 0  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- Move return statements outside `async with async_session.begin()` blocks in all 5 methods of `DiscordVerificationRepo` to make transaction boundaries explicit
- Remove redundant `await async_session.commit()` calls inside `begin()` context manager (which auto-commits on clean exit)

Closes #133, Closes #134