### PR TITLE
Replace json.dumps with orjson in hiscore repository

### DIFF
--- a/components/bot_detector/database/hiscore/repository.py
+++ b/components/bot_detector/database/hiscore/repository.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 import logging
 
 import sqlalchemy as sqla
@@ -156,8 +156,8 @@ class HighscoreDataRepo(HighscoreDataLatestInterface):
             _data = {
                 "player_id": data.player_id,
                 "scrape_date": data.scrape_date.isoformat(),
-                "skills": json.dumps(data.skills),
-                "activities": json.dumps(data.activities),
+                "skills": orjson.dumps(data.skills).decode(),
+                "activities": orjson.dumps(data.activities).decode(),
             }
             data_list.append(_data)
 


### PR DESCRIPTION
## Summary

- Replace `import json` with `import orjson` in `components/bot_detector/database/hiscore/repository.py`
- Replace `json.dumps(...)` calls with `orjson.dumps(...).decode()` for skills/activities serialization
- Aligns with AGENTS.md guideline: use orjson for all JSON serialization

Closes #130