### PR TITLE
Add asyncio Lock to osrs_items cache refresh to prevent thundering herd

### DIFF
--- a/components/bot_detector/osrs_items/core.py
+++ b/components/bot_detector/osrs_items/core.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta
 
 import aiohttp
@@ -26,6 +27,7 @@ class OsrsItemsClient:
         self._items_by_id: dict[int, ItemStruct] = {}
         self._items_by_name: dict[str, ItemStruct] = {}
         self._loaded_at: datetime | None = None
+        self._lock = asyncio.Lock()
 
     async def _load_items(self) -> None:
         headers = {"User-Agent": self.user_agent}
@@ -54,7 +56,9 @@ class OsrsItemsClient:
 
     async def _refresh_if_stale(self) -> None:
         if self._loaded_at is None or self._is_stale():
-            await self._load_items()
+            async with self._lock:
+                if self._loaded_at is None or self._is_stale():
+                    await self._load_items()
 
     async def lookup_by_item_id(self, item_id: int) -> ItemStruct | None:
         await self._refresh_if_stale()

--- a/test/components/bot_detector/osrs_items/test_core.py
+++ b/test/components/bot_detector/osrs_items/test_core.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 import pytest_asyncio
 from datetime import datetime, timedelta
@@ -287,4 +289,23 @@ async def test_lazy_load_on_first_lookup(session, sample_items_data):
 
         assert result is not None
         assert client._loaded_at is not None
+        assert len(client._items_by_id) == 3
+
+
+@pytest.mark.asyncio
+async def test_thundering_herd_only_one_request(session, sample_items_data):
+    client = OsrsItemsClient(session=session, user_agent=TEST_USER_AGENT)
+    client._loaded_at = datetime.now() - timedelta(hours=25)
+
+    with aioresponses() as m:
+        m.get(
+            "https://prices.runescape.wiki/api/v1/osrs/mapping",
+            payload=sample_items_data,
+            status=200,
+        )
+
+        coros = [client.lookup_by_item_id(1) for _ in range(10)]
+        results = await asyncio.gather(*coros)
+
+        assert all(r is not None for r in results)
         assert len(client._items_by_id) == 3


### PR DESCRIPTION
## Summary

- Closes #132
- Adds `asyncio.Lock` to `OsrsItemsClient` with double-check locking in `_refresh_if_stale()` to prevent thundering herd on stale cache
- When multiple concurrent coroutines hit a stale cache, only the first acquires the lock and loads data; others skip after seeing the refreshed `_loaded_at`

## Changes

- `components/bot_detector/osrs_items/core.py` — `self._lock = asyncio.Lock()` in `__init__`, `async with self._lock` + double-check in `_refresh_if_stale`
- `test/components/bot_detector/osrs_items/test_core.py` — `test_thundering_herd_only_one_request`: 10 concurrent lookups with only 1 mock registered, proving single HTTP call