### PR TITLE
feat(database): add feedback domain with export repository

### DIFF
--- a/components/bot_detector/database/feedback/__init__.py
+++ b/components/bot_detector/database/feedback/__init__.py
@@ -1,0 +1,4 @@
+from .repository import FeedbackExportRepo
+from .structs import PredictionFeedbackTableStruct
+
+__all__ = ["FeedbackExportRepo", "PredictionFeedbackTableStruct"]

--- a/components/bot_detector/database/feedback/__init__.py
+++ b/components/bot_detector/database/feedback/__init__.py
@@ -1,4 +1,4 @@
-from .repository import FeedbackExportRepo
-from .structs import PredictionFeedbackTableStruct
+from bot_detector.database.feedback.repository import FeedbackExportRepo
+from bot_detector.database.feedback.structs import PredictionFeedbackTableStruct
 
 __all__ = ["FeedbackExportRepo", "PredictionFeedbackTableStruct"]

--- a/components/bot_detector/database/feedback/repository.py
+++ b/components/bot_detector/database/feedback/repository.py
@@ -7,7 +7,7 @@ from sqlalchemy import case
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from .structs import PredictionFeedbackTableStruct
+from bot_detector.database.feedback.structs import PredictionFeedbackTableStruct
 
 logger = logging.getLogger(__name__)
 

--- a/components/bot_detector/database/feedback/repository.py
+++ b/components/bot_detector/database/feedback/repository.py
@@ -1,0 +1,45 @@
+import logging
+
+import sqlalchemy as sqla
+from bot_detector.database.player.structs import PlayersTableStruct
+from bot_detector.structs import FeedbackExportItem
+from sqlalchemy import case
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from .structs import PredictionFeedbackTableStruct
+
+logger = logging.getLogger(__name__)
+
+
+class FeedbackExportRepo:
+    async def get_feedback_export(
+        self,
+        async_session: AsyncSession,
+        voter_player_id: int,
+    ) -> list[FeedbackExportItem]:
+        p_subject = aliased(PlayersTableStruct, name="export_subject")
+
+        is_banned_expr = case(
+            (
+                sqla.and_(
+                    p_subject.possible_ban == True,  # noqa: E712
+                    p_subject.label_jagex == 2,
+                ),
+                True,
+            ),
+            else_=False,
+        )
+
+        sql = sqla.select(
+            p_subject.name.label("subject_name"),
+            is_banned_expr.label("is_banned"),
+            PredictionFeedbackTableStruct.vote,
+            PredictionFeedbackTableStruct.prediction,
+        ).where(
+            PredictionFeedbackTableStruct.voter_id == voter_player_id,
+        )
+
+        result = await async_session.execute(sql)
+        rows = result.mappings().all()
+        return [FeedbackExportItem(**row) for row in rows]

--- a/components/bot_detector/database/feedback/repository.py
+++ b/components/bot_detector/database/feedback/repository.py
@@ -16,30 +16,51 @@ class FeedbackExportRepo:
     async def get_feedback_export(
         self,
         async_session: AsyncSession,
-        voter_player_id: int,
+        voter_player_id: int | None = None,
+        voter_player_name: str | None = None,
     ) -> list[FeedbackExportItem]:
-        p_subject = aliased(PlayersTableStruct, name="export_subject")
+        if voter_player_id is None and voter_player_name is None:
+            raise ValueError(
+                "Either voter_player_id or voter_player_name must be provided"
+            )
+
+        feedback = aliased(PredictionFeedbackTableStruct, name="feedback")
+        voter = aliased(PlayersTableStruct, name="voter")
+        subject = aliased(PlayersTableStruct, name="subject")
 
         is_banned_expr = case(
             (
                 sqla.and_(
-                    p_subject.possible_ban == True,  # noqa: E712
-                    p_subject.label_jagex == 2,
+                    subject.possible_ban == 1,
+                    subject.label_jagex == 2,
                 ),
                 True,
             ),
             else_=False,
         )
 
-        sql = sqla.select(
-            p_subject.name.label("subject_name"),
-            is_banned_expr.label("is_banned"),
-            PredictionFeedbackTableStruct.vote,
-            PredictionFeedbackTableStruct.prediction,
-        ).where(
-            PredictionFeedbackTableStruct.voter_id == voter_player_id,
+        sql = (
+            sqla.select(
+                subject.name.label("subject_name"),
+                is_banned_expr.label("is_banned"),
+                feedback.vote,
+                feedback.prediction,
+            )
+            .join(
+                feedback,
+                feedback.subject_id == subject.id,
+            )
+            .join(
+                voter,
+                feedback.voter_id == voter.id,
+            )
         )
+
+        if voter_player_id is not None:
+            sql = sql.where(voter.id == voter_player_id)
+        if voter_player_name is not None:
+            sql = sql.where(voter.name == voter_player_name)
 
         result = await async_session.execute(sql)
         rows = result.mappings().all()
-        return [FeedbackExportItem(**row) for row in rows]
+        return [FeedbackExportItem.model_validate(row) for row in rows]

--- a/components/bot_detector/database/feedback/structs.py
+++ b/components/bot_detector/database/feedback/structs.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+
+from bot_detector.database import Base
+from sqlalchemy import (
+    Float,
+    ForeignKey,
+    Integer,
+    SmallInteger,
+    String,
+    Text,
+    TIMESTAMP,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class PredictionFeedbackTableStruct(Base):
+    __tablename__ = "PredictionsFeedback"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    ts: Mapped[datetime] = mapped_column(
+        TIMESTAMP, nullable=False, server_default="CURRENT_TIMESTAMP"
+    )
+    voter_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("Players.id"), nullable=False
+    )
+    subject_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("Players.id"), nullable=False
+    )
+    prediction: Mapped[str] = mapped_column(String(50), nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    vote: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    reviewed: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default="0"
+    )
+    user_notified: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default="0"
+    )
+    feedback_text: Mapped[str | None] = mapped_column(
+        Text(collation="utf8mb4_0900_ai_ci"), default=None
+    )
+    reviewer_id: Mapped[int | None] = mapped_column(Integer, default=None)
+    proposed_label: Mapped[str | None] = mapped_column(String(50), default=None)

--- a/components/bot_detector/structs/__init__.py
+++ b/components/bot_detector/structs/__init__.py
@@ -1,4 +1,5 @@
 from ._metadata import MetaData
+from .feedback import FeedbackExportItem
 from .hiscore import (
     HighscoreBaseStruct,
     HighscoreDataBaseStruct,
@@ -19,6 +20,7 @@ from .reports import Detection, Equipment, ParsedDetection
 
 __all__ = [
     "MetaData",
+    "FeedbackExportItem",
     "HighscoreBaseStruct",
     "HighscoreDataLatestStruct",
     "HighscoreDataBaseStruct",

--- a/components/bot_detector/structs/feedback.py
+++ b/components/bot_detector/structs/feedback.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class FeedbackExportItem(BaseModel):
+    subject_name: str
+    is_banned: bool
+    vote: int
+    prediction: str

--- a/test/components/bot_detector/database/test_feedback_repository.py
+++ b/test/components/bot_detector/database/test_feedback_repository.py
@@ -102,3 +102,60 @@ async def test_get_feedback_export_multiple_rows_same_voter():
     result = await repo.get_feedback_export(session, voter_player_id=5)
 
     assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_export_by_name():
+    rows = [
+        {
+            "subject_name": "player1",
+            "is_banned": True,
+            "vote": 1,
+            "prediction": "bot",
+        },
+    ]
+    session = _mock_session(rows)
+    repo = FeedbackExportRepo()
+
+    result = await repo.get_feedback_export(session, voter_player_name="voter123")
+
+    assert len(result) == 1
+    assert result[0].subject_name == "player1"
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_export_by_name_returns_empty():
+    session = _mock_session([])
+    repo = FeedbackExportRepo()
+
+    result = await repo.get_feedback_export(session, voter_player_name="nobody")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_export_by_id_and_name():
+    rows = [
+        {
+            "subject_name": "player1",
+            "is_banned": False,
+            "vote": 0,
+            "prediction": "human",
+        },
+    ]
+    session = _mock_session(rows)
+    repo = FeedbackExportRepo()
+
+    result = await repo.get_feedback_export(
+        session, voter_player_id=42, voter_player_name="voter123"
+    )
+
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_export_raises_when_no_identifier():
+    repo = FeedbackExportRepo()
+
+    with pytest.raises(ValueError, match="Either voter_player_id or voter_player_name"):
+        await repo.get_feedback_export(AsyncMock())

--- a/test/components/bot_detector/database/test_feedback_repository.py
+++ b/test/components/bot_detector/database/test_feedback_repository.py
@@ -1,0 +1,104 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bot_detector.database.feedback import FeedbackExportRepo
+from bot_detector.structs import FeedbackExportItem
+
+
+def _mock_session(rows: list[dict]) -> AsyncMock:
+    session = AsyncMock()
+    mappings_mock = MagicMock()
+    mappings_mock.all.return_value = rows
+    result_mock = MagicMock()
+    result_mock.mappings.return_value = mappings_mock
+    session.execute.return_value = result_mock
+    return session
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_export_returns_items():
+    rows = [
+        {
+            "subject_name": "player1",
+            "is_banned": True,
+            "vote": 1,
+            "prediction": "bot",
+        },
+        {
+            "subject_name": "player2",
+            "is_banned": False,
+            "vote": 0,
+            "prediction": "human",
+        },
+    ]
+    session = _mock_session(rows)
+    repo = FeedbackExportRepo()
+
+    result = await repo.get_feedback_export(session, voter_player_id=42)
+
+    assert len(result) == 2
+    assert result[0] == FeedbackExportItem(
+        subject_name="player1", is_banned=True, vote=1, prediction="bot"
+    )
+    assert result[1] == FeedbackExportItem(
+        subject_name="player2", is_banned=False, vote=0, prediction="human"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_export_returns_empty_for_no_feedback():
+    session = _mock_session([])
+    repo = FeedbackExportRepo()
+
+    result = await repo.get_feedback_export(session, voter_player_id=999)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_export_ban_status_false_when_not_banned():
+    rows = [
+        {
+            "subject_name": "player3",
+            "is_banned": False,
+            "vote": 1,
+            "prediction": "bot",
+        },
+    ]
+    session = _mock_session(rows)
+    repo = FeedbackExportRepo()
+
+    result = await repo.get_feedback_export(session, voter_player_id=10)
+
+    assert len(result) == 1
+    assert result[0].is_banned is False
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_export_multiple_rows_same_voter():
+    rows = [
+        {
+            "subject_name": "player_a",
+            "is_banned": True,
+            "vote": 1,
+            "prediction": "bot",
+        },
+        {
+            "subject_name": "player_a",
+            "is_banned": True,
+            "vote": 0,
+            "prediction": "human",
+        },
+        {
+            "subject_name": "player_b",
+            "is_banned": False,
+            "vote": 1,
+            "prediction": "bot",
+        },
+    ]
+    session = _mock_session(rows)
+    repo = FeedbackExportRepo()
+
+    result = await repo.get_feedback_export(session, voter_player_id=5)
+
+    assert len(result) == 3


### PR DESCRIPTION
## Summary

- Add `components/bot_detector/database/feedback/` feature directory with `PredictionFeedbackTableStruct` (Mapped/mapped_column style) and `FeedbackExportRepo`
- Add `FeedbackExportItem` shared Pydantic struct to `components/bot_detector/structs/`
- Repository `get_feedback_export` joins `PredictionsFeedback` + aliased `Players`, computes `is_banned` via `case()` in SQL (`possible_ban == True AND label_jagex == 2`)
- 4 tests covering voter with feedback, empty result, ban status mapping, and multiple rows

## Files

| File | Description |
|------|-------------|
| `components/bot_detector/structs/feedback.py` | `FeedbackExportItem` Pydantic model |
| `components/bot_detector/database/feedback/structs.py` | `PredictionFeedbackTableStruct` SQLAlchemy table |
| `components/bot_detector/database/feedback/repository.py` | `FeedbackExportRepo.get_feedback_export()` |
| `components/bot_detector/database/feedback/__init__.py` | Re-exports |
| `test/.../test_feedback_repository.py` | 4 async tests |

## Test plan

- [x] `uv run pytest test/components/bot_detector/database/test_feedback_repository.py` — 4 passed
- [x] `uv run ruff check` — all clean
- [x] `uv run pytest` — 243 passed (11 pre-existing failures unrelated)