### PR TITLE
feat(api_public): standardize wide_event logging to _fn-keyed pattern

### DIFF
--- a/bases/bot_detector/api_public/src/api/v2/feedback.py
+++ b/bases/bot_detector/api_public/src/api/v2/feedback.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Annotated
 
 from bot_detector.api_public.src.app.views.input.feedback import FeedbackInput
@@ -15,7 +14,6 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic.fields import Field
 
 router = APIRouter(tags=["Feedback"])
-logger = logging.getLogger(__name__)
 
 _feedback_export_repo = FeedbackExportRepo()
 

--- a/bases/bot_detector/api_public/src/api/v2/labels.py
+++ b/bases/bot_detector/api_public/src/api/v2/labels.py
@@ -1,12 +1,10 @@
-import logging
-
 from bot_detector.api_public.src.app.views.response.label import LabelResponse
+from bot_detector.api_public.src.core.fastapi.dependencies import wide_event
 from bot_detector.api_public.src.core.fastapi.dependencies.session import get_session
 from bot_detector.database.api_public import LabelRepo
 from fastapi import APIRouter, Depends, status
 
 router = APIRouter(tags=["Labels"])
-logger = logging.getLogger(__name__)
 
 
 @router.get(
@@ -15,6 +13,8 @@ logger = logging.getLogger(__name__)
     status_code=status.HTTP_200_OK,
 )
 async def get_labels(session=Depends(get_session)):
+    _fn = get_labels.__name__
+    wide_event.add_context({_fn: {}})
     _label_repo = LabelRepo(session)
     labels = await _label_repo.get_labels()
 
@@ -23,6 +23,7 @@ async def get_labels(session=Depends(get_session)):
         _label = LabelResponse(**label.__dict__)
         _label.label = _label.label.lower()
         _labels.append(_label)
+    wide_event.add_context({_fn: {"status": "success", "labels_count": len(_labels)}})
     return _labels
 
 
@@ -34,11 +35,15 @@ async def get_labels(session=Depends(get_session)):
 async def get_label_by_id(
     label_id: int, session=Depends(get_session)
 ) -> LabelResponse | None:
+    _fn = get_label_by_id.__name__
+    wide_event.add_context({_fn: {"label_id": label_id}})
     _label_repo = LabelRepo(session)
     label = await _label_repo.get_label_by_id(label_id=label_id)
 
     if label is None:
+        wide_event.add_context({_fn: {"status": "not_found", "label_id": label_id}})
         return None
     _label = LabelResponse(**label.__dict__)
     _label.label = _label.label.lower()
+    wide_event.add_context({_fn: {"status": "success", "label_id": label_id}})
     return _label

--- a/bases/bot_detector/api_public/src/api/v2/player.py
+++ b/bases/bot_detector/api_public/src/api/v2/player.py
@@ -8,6 +8,7 @@ from bot_detector.api_public.src.app.views.response.prediction import Prediction
 from bot_detector.api_public.src.app.views.response.report_score import (
     ReportScoreResponse,
 )
+from bot_detector.api_public.src.core.fastapi.dependencies import wide_event
 from bot_detector.api_public.src.core.fastapi.dependencies.session import get_session
 from bot_detector.api_public.src.core.fastapi.dependencies.to_jagex_name import (
     to_jagex_name,
@@ -29,9 +30,12 @@ async def get_players_kc(
     ),
     session=Depends(get_session),
 ):
+    _fn = get_players_kc.__name__
     repo = PlayerRepo(session)
     names = await asyncio.gather(*[to_jagex_name(n) for n in name])
+    wide_event.add_context({_fn: {"names": names}})
     data = await repo.get_report_score(player_names=tuple(names))
+    wide_event.add_context({_fn: {"status": "success", "results_count": len(data)}})
     return data
 
 
@@ -45,9 +49,12 @@ async def get_feedback_score(
     ),
     session=Depends(get_session),
 ):
+    _fn = get_feedback_score.__name__
     repo = PlayerRepo(session)
     names = await asyncio.gather(*[to_jagex_name(n) for n in name])
+    wide_event.add_context({_fn: {"names": names}})
     data = await repo.get_feedback_score(player_names=names)
+    wide_event.add_context({_fn: {"status": "success", "results_count": len(data)}})
     return data
 
 
@@ -63,12 +70,16 @@ async def get_prediction(
     breakdown: bool = Query(...),
     session=Depends(get_session),
 ):
+    _fn = get_prediction.__name__
     repo = PlayerRepo(session)
     names = await asyncio.gather(*[to_jagex_name(n) for n in name])
+    wide_event.add_context({_fn: {"names": names, "breakdown": breakdown}})
     data = await repo.get_prediction(player_names=names)
     if not data:
+        wide_event.add_context({_fn: {"error": "Player not found"}})
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Player not found",
         )
+    wide_event.add_context({_fn: {"status": "success", "results_count": len(data)}})
     return [PredictionResponse.from_data(d, breakdown) for d in data]

--- a/bases/bot_detector/api_public/src/api/v2/report.py
+++ b/bases/bot_detector/api_public/src/api/v2/report.py
@@ -40,13 +40,14 @@ async def post_reports(
         get_reports_to_insert_producer
     ),
 ):
+    _fn = post_reports.__name__
     global player_cache
     report_service = ReportService()
     player_repo = PlayerRepo(session=session)
 
     wide_event.add_context(
         {
-            "report": {
+            _fn: {
                 "reports_received": len(detections),
                 "sample_report": detections[0].model_dump() if detections else None,
             }
@@ -58,7 +59,7 @@ async def post_reports(
 
     wide_event.add_context(
         {
-            "report": {
+            _fn: {
                 "valid_reports_received": len(data),
                 "reporter": data[0].reporter,
             }
@@ -83,11 +84,13 @@ async def post_reports(
         if reporter_id is None or reported_id is None:
             wide_event.add_context(
                 {
-                    "report": {
-                        "status": "error",
-                        "detail": "invalid_reporter_or_reported, could not find player id",
-                        "reported": reported,
-                        "reporter": reporter,
+                    _fn: {
+                        "error": {
+                            "status": "error",
+                            "detail": "invalid_reporter_or_reported, could not find player id",
+                            "reported": reported,
+                            "reporter": reporter,
+                        }
                     }
                 }
             )
@@ -107,10 +110,12 @@ async def post_reports(
     if produce_errors:
         wide_event.add_context(
             {
-                "report": {
-                    "status": "error",
-                    "detail": str(produce_errors[0]),
-                    "produce_errors": len(produce_errors),
+                _fn: {
+                    "error": {
+                        "status": "error",
+                        "detail": str(produce_errors[0]),
+                        "produce_errors": len(produce_errors),
+                    }
                 }
             }
         )

--- a/bases/bot_detector/api_public/src/api/v2/user.py
+++ b/bases/bot_detector/api_public/src/api/v2/user.py
@@ -1,13 +1,12 @@
-import logging
-
-from bot_detector.api_public.src.core.fastapi.dependencies import auth
+from bot_detector.api_public.src.core.fastapi.dependencies import auth, wide_event
 from bot_detector.database.api.structs import ApiUserTableStruct
 from fastapi import APIRouter, Depends
 
 router = APIRouter(tags=["User"])
-logger = logging.getLogger(__name__)
 
 
 @router.get("/users/me", tags=["Private"])
 def read_current_user(user: ApiUserTableStruct = Depends(auth.get_current_user)):
+    _fn = read_current_user.__name__
+    wide_event.add_context({_fn: {"status": "called"}})
     return {"username": user.username, "password": user.token}

--- a/bases/bot_detector/api_public/src/app/report.py
+++ b/bases/bot_detector/api_public/src/app/report.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import time
 
 from bot_detector.api_public.src.core.fastapi.dependencies import wide_event
@@ -12,8 +11,6 @@ from bot_detector.structs import (
 )
 from pydantic import ValidationError
 
-logger = logging.getLogger(__name__)
-
 
 class CustomError(Exception): ...
 
@@ -23,6 +20,7 @@ class ReportService:
         return None if len(data) > 5000 else data
 
     def _filter_valid_time(self, data: list[Detection]) -> list[Detection]:
+        _fn = self._filter_valid_time.__name__
         current_time = int(time.time())
         min_ts = current_time - 25200
         max_ts = current_time + 3600
@@ -40,7 +38,7 @@ class ReportService:
             output.append(d)
         wide_event.add_context(
             {
-                "report": {
+                _fn: {
                     "stale_report_count": stale_report_count,
                     "future_report_count": future_report_count,
                 }
@@ -49,27 +47,29 @@ class ReportService:
         return output
 
     def _check_unique_reporter(self, data: list[Detection]) -> list[Detection] | None:
+        _fn = self._check_unique_reporter.__name__
         reporters = set(d.reporter for d in data)
-        wide_event.add_context({"report": {"reporters": list(reporters)}})
+        wide_event.add_context({_fn: {"reporters": list(reporters)}})
         return None if len(reporters) > 1 else data
 
     async def parse_data(self, data: list[Detection]) -> tuple[list[Detection], None]:
+        _fn = self.parse_data.__name__
         data = self._check_data_size(data)
         if not data:
             error = "invalid data size"
-            wide_event.add_context({"report": {"status": "error", "detail": error}})
+            wide_event.add_context({_fn: {"status": "error", "detail": error}})
             return None, error
 
         data = self._filter_valid_time(data)
         if not data:
             error = "invalid time"
-            wide_event.add_context({"report": {"status": "error", "detail": error}})
+            wide_event.add_context({_fn: {"status": "error", "detail": error}})
             return None, error
 
         data = self._check_unique_reporter(data)
         if not data:
             error = "invalid unique reporter"
-            wide_event.add_context({"report": {"status": "error", "detail": error}})
+            wide_event.add_context({_fn: {"status": "error", "detail": error}})
             return None, error
         return data, None
 
@@ -94,6 +94,7 @@ class ReportService:
         data: list[ParsedDetection],
         producer: QueueProducer[ReportsToInsertStruct],
     ) -> list[Exception]:
+        _fn = self.send_to_queue.__name__
         reports, error = self._transform_detection(data)
 
         tasks = [producer.put([report]) for report in reports]
@@ -105,7 +106,7 @@ class ReportService:
         if len(error) > 0:
             wide_event.add_context(
                 {
-                    "report": {
+                    _fn: {
                         "reports_sent_to_queue": len(reports),
                         "report_errors": len(error),
                     }

--- a/test/bases/bot_detector/api_public/test_wide_event_context.py
+++ b/test/bases/bot_detector/api_public/test_wide_event_context.py
@@ -33,9 +33,7 @@ def _make_detection(**overrides) -> Detection:
 
 @pytest.mark.asyncio
 async def test_report_service_parse_data_uses_fn_key_on_data_size_error():
-    with patch(
-        "bot_detector.api_public.src.app.report.wide_event"
-    ) as mock_we:
+    with patch("bot_detector.api_public.src.app.report.wide_event") as mock_we:
         service = ReportService()
         detections = [_make_detection() for _ in range(5001)]
         await service.parse_data(detections)
@@ -46,9 +44,7 @@ async def test_report_service_parse_data_uses_fn_key_on_data_size_error():
 
 @pytest.mark.asyncio
 async def test_report_service_parse_data_uses_fn_key_on_time_error():
-    with patch(
-        "bot_detector.api_public.src.app.report.wide_event"
-    ) as mock_we:
+    with patch("bot_detector.api_public.src.app.report.wide_event") as mock_we:
         service = ReportService()
         detections = [_make_detection(ts=int(time.time()) - 30000)]
         await service.parse_data(detections)
@@ -59,9 +55,7 @@ async def test_report_service_parse_data_uses_fn_key_on_time_error():
 
 @pytest.mark.asyncio
 async def test_report_service_parse_data_uses_fn_key_on_reporter_error():
-    with patch(
-        "bot_detector.api_public.src.app.report.wide_event"
-    ) as mock_we:
+    with patch("bot_detector.api_public.src.app.report.wide_event") as mock_we:
         service = ReportService()
         detections = [
             _make_detection(reporter="reporter_a"),
@@ -75,9 +69,7 @@ async def test_report_service_parse_data_uses_fn_key_on_reporter_error():
 
 @pytest.mark.asyncio
 async def test_report_service_filter_valid_time_uses_fn_key():
-    with patch(
-        "bot_detector.api_public.src.app.report.wide_event"
-    ) as mock_we:
+    with patch("bot_detector.api_public.src.app.report.wide_event") as mock_we:
         service = ReportService()
         detections = [_make_detection()]
         service._filter_valid_time(detections)
@@ -89,9 +81,7 @@ async def test_report_service_filter_valid_time_uses_fn_key():
 
 @pytest.mark.asyncio
 async def test_report_service_check_unique_reporter_uses_fn_key():
-    with patch(
-        "bot_detector.api_public.src.app.report.wide_event"
-    ) as mock_we:
+    with patch("bot_detector.api_public.src.app.report.wide_event") as mock_we:
         service = ReportService()
         detections = [_make_detection()]
         service._check_unique_reporter(detections)
@@ -102,9 +92,7 @@ async def test_report_service_check_unique_reporter_uses_fn_key():
 
 @pytest.mark.asyncio
 async def test_report_service_send_to_queue_uses_fn_key():
-    with patch(
-        "bot_detector.api_public.src.app.report.wide_event"
-    ) as mock_we:
+    with patch("bot_detector.api_public.src.app.report.wide_event") as mock_we:
         service = ReportService()
         parsed = MagicMock()
         parsed.model_dump.return_value = {
@@ -131,19 +119,13 @@ async def test_report_service_send_to_queue_uses_fn_key():
 @pytest.mark.asyncio
 async def test_player_get_players_kc_adds_entry_and_success_context():
     with (
-        patch(
-            "bot_detector.api_public.src.api.v2.player.wide_event"
-        ) as mock_we,
-        patch(
-            "bot_detector.api_public.src.api.v2.player.PlayerRepo"
-        ) as mock_repo_cls,
+        patch("bot_detector.api_public.src.api.v2.player.wide_event") as mock_we,
+        patch("bot_detector.api_public.src.api.v2.player.PlayerRepo") as mock_repo_cls,
         patch(
             "bot_detector.api_public.src.api.v2.player.to_jagex_name",
             side_effect=lambda n: AsyncMock(_return_value=n)() if False else n,
         ),
-        patch(
-            "bot_detector.api_public.src.api.v2.player.asyncio"
-        ) as mock_asyncio,
+        patch("bot_detector.api_public.src.api.v2.player.asyncio") as mock_asyncio,
     ):
         mock_asyncio.gather = AsyncMock(return_value=["player1"])
         mock_repo = MagicMock()
@@ -158,10 +140,11 @@ async def test_player_get_players_kc_adds_entry_and_success_context():
         )
 
         calls = [c[0][0] for c in mock_we.add_context.call_args_list]
-        assert any("get_players_kc" in c and "names" in c["get_players_kc"] for c in calls)
         assert any(
-            "get_players_kc" in c
-            and c["get_players_kc"].get("status") == "success"
+            "get_players_kc" in c and "names" in c["get_players_kc"] for c in calls
+        )
+        assert any(
+            "get_players_kc" in c and c["get_players_kc"].get("status") == "success"
             for c in calls
         )
 
@@ -169,15 +152,9 @@ async def test_player_get_players_kc_adds_entry_and_success_context():
 @pytest.mark.asyncio
 async def test_player_get_feedback_score_adds_entry_and_success_context():
     with (
-        patch(
-            "bot_detector.api_public.src.api.v2.player.wide_event"
-        ) as mock_we,
-        patch(
-            "bot_detector.api_public.src.api.v2.player.PlayerRepo"
-        ) as mock_repo_cls,
-        patch(
-            "bot_detector.api_public.src.api.v2.player.asyncio"
-        ) as mock_asyncio,
+        patch("bot_detector.api_public.src.api.v2.player.wide_event") as mock_we,
+        patch("bot_detector.api_public.src.api.v2.player.PlayerRepo") as mock_repo_cls,
+        patch("bot_detector.api_public.src.api.v2.player.asyncio") as mock_asyncio,
     ):
         mock_asyncio.gather = AsyncMock(return_value=["player1"])
         mock_repo = MagicMock()
@@ -192,7 +169,10 @@ async def test_player_get_feedback_score_adds_entry_and_success_context():
         )
 
         calls = [c[0][0] for c in mock_we.add_context.call_args_list]
-        assert any("get_feedback_score" in c and "names" in c["get_feedback_score"] for c in calls)
+        assert any(
+            "get_feedback_score" in c and "names" in c["get_feedback_score"]
+            for c in calls
+        )
         assert any(
             "get_feedback_score" in c
             and c["get_feedback_score"].get("status") == "success"
@@ -203,15 +183,9 @@ async def test_player_get_feedback_score_adds_entry_and_success_context():
 @pytest.mark.asyncio
 async def test_player_get_prediction_adds_entry_context():
     with (
-        patch(
-            "bot_detector.api_public.src.api.v2.player.wide_event"
-        ) as mock_we,
-        patch(
-            "bot_detector.api_public.src.api.v2.player.PlayerRepo"
-        ) as mock_repo_cls,
-        patch(
-            "bot_detector.api_public.src.api.v2.player.asyncio"
-        ) as mock_asyncio,
+        patch("bot_detector.api_public.src.api.v2.player.wide_event") as mock_we,
+        patch("bot_detector.api_public.src.api.v2.player.PlayerRepo") as mock_repo_cls,
+        patch("bot_detector.api_public.src.api.v2.player.asyncio") as mock_asyncio,
     ):
         mock_asyncio.gather = AsyncMock(return_value=["player1"])
         mock_repo = MagicMock()
@@ -243,15 +217,9 @@ async def test_player_get_prediction_adds_entry_context():
 @pytest.mark.asyncio
 async def test_player_get_prediction_adds_error_context_on_not_found():
     with (
-        patch(
-            "bot_detector.api_public.src.api.v2.player.wide_event"
-        ) as mock_we,
-        patch(
-            "bot_detector.api_public.src.api.v2.player.PlayerRepo"
-        ) as mock_repo_cls,
-        patch(
-            "bot_detector.api_public.src.api.v2.player.asyncio"
-        ) as mock_asyncio,
+        patch("bot_detector.api_public.src.api.v2.player.wide_event") as mock_we,
+        patch("bot_detector.api_public.src.api.v2.player.PlayerRepo") as mock_repo_cls,
+        patch("bot_detector.api_public.src.api.v2.player.asyncio") as mock_asyncio,
     ):
         mock_asyncio.gather = AsyncMock(return_value=["player1"])
         mock_repo = MagicMock()
@@ -279,12 +247,8 @@ async def test_player_get_prediction_adds_error_context_on_not_found():
 @pytest.mark.asyncio
 async def test_labels_get_labels_adds_entry_and_success_context():
     with (
-        patch(
-            "bot_detector.api_public.src.api.v2.labels.wide_event"
-        ) as mock_we,
-        patch(
-            "bot_detector.api_public.src.api.v2.labels.LabelRepo"
-        ) as mock_repo_cls,
+        patch("bot_detector.api_public.src.api.v2.labels.wide_event") as mock_we,
+        patch("bot_detector.api_public.src.api.v2.labels.LabelRepo") as mock_repo_cls,
     ):
         mock_label = MagicMock()
         mock_label.__dict__ = {"label": "Bot", "id": 1}
@@ -316,12 +280,8 @@ async def test_labels_get_labels_adds_entry_and_success_context():
 @pytest.mark.asyncio
 async def test_labels_get_label_by_id_adds_entry_and_success_context():
     with (
-        patch(
-            "bot_detector.api_public.src.api.v2.labels.wide_event"
-        ) as mock_we,
-        patch(
-            "bot_detector.api_public.src.api.v2.labels.LabelRepo"
-        ) as mock_repo_cls,
+        patch("bot_detector.api_public.src.api.v2.labels.wide_event") as mock_we,
+        patch("bot_detector.api_public.src.api.v2.labels.LabelRepo") as mock_repo_cls,
     ):
         mock_label = MagicMock()
         mock_label.__dict__ = {"label": "Bot", "id": 1}
@@ -346,8 +306,7 @@ async def test_labels_get_label_by_id_adds_entry_and_success_context():
             for c in calls
         )
         assert any(
-            "get_label_by_id" in c
-            and c["get_label_by_id"].get("status") == "success"
+            "get_label_by_id" in c and c["get_label_by_id"].get("status") == "success"
             for c in calls
         )
 
@@ -355,12 +314,8 @@ async def test_labels_get_label_by_id_adds_entry_and_success_context():
 @pytest.mark.asyncio
 async def test_labels_get_label_by_id_not_found_context():
     with (
-        patch(
-            "bot_detector.api_public.src.api.v2.labels.wide_event"
-        ) as mock_we,
-        patch(
-            "bot_detector.api_public.src.api.v2.labels.LabelRepo"
-        ) as mock_repo_cls,
+        patch("bot_detector.api_public.src.api.v2.labels.wide_event") as mock_we,
+        patch("bot_detector.api_public.src.api.v2.labels.LabelRepo") as mock_repo_cls,
     ):
         mock_repo = MagicMock()
         mock_repo.get_label_by_id = AsyncMock(return_value=None)
@@ -381,9 +336,7 @@ async def test_labels_get_label_by_id_not_found_context():
 
 
 def test_user_read_current_user_adds_called_context():
-    with patch(
-        "bot_detector.api_public.src.api.v2.user.wide_event"
-    ) as mock_we:
+    with patch("bot_detector.api_public.src.api.v2.user.wide_event") as mock_we:
         mock_user = MagicMock()
         mock_user.username = "testuser"
         mock_user.token = "testtoken"
@@ -400,15 +353,11 @@ def test_user_read_current_user_adds_called_context():
 @pytest.mark.asyncio
 async def test_report_post_reports_uses_fn_key():
     with (
-        patch(
-            "bot_detector.api_public.src.api.v2.report.wide_event"
-        ) as mock_we,
+        patch("bot_detector.api_public.src.api.v2.report.wide_event") as mock_we,
         patch(
             "bot_detector.api_public.src.api.v2.report.ReportService"
         ) as mock_svc_cls,
-        patch(
-            "bot_detector.api_public.src.api.v2.report.PlayerRepo"
-        ) as mock_repo_cls,
+        patch("bot_detector.api_public.src.api.v2.report.PlayerRepo") as mock_repo_cls,
         patch(
             "bot_detector.api_public.src.api.v2.report._get_or_insert_cached",
             new_callable=AsyncMock,

--- a/test/bases/bot_detector/api_public/test_wide_event_context.py
+++ b/test/bases/bot_detector/api_public/test_wide_event_context.py
@@ -1,0 +1,448 @@
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "mysql+asyncmy://test:test@localhost/test")
+os.environ.setdefault("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+
+from bot_detector.api_public.src.app.report import ReportService
+from bot_detector.structs import Detection, Equipment
+
+
+def _make_detection(**overrides) -> Detection:
+    defaults = dict(
+        reporter="testreporter",
+        reported="testreported",
+        region_id=0,
+        x_coord=0,
+        y_coord=0,
+        z_coord=0,
+        ts=int(time.time()),
+        manual_detect=0,
+        on_members_world=0,
+        on_pvp_world=0,
+        world_number=500,
+        equipment=Equipment(),
+        equip_ge_value=0,
+    )
+    defaults.update(overrides)
+    return Detection(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_report_service_parse_data_uses_fn_key_on_data_size_error():
+    with patch(
+        "bot_detector.api_public.src.app.report.wide_event"
+    ) as mock_we:
+        service = ReportService()
+        detections = [_make_detection() for _ in range(5001)]
+        await service.parse_data(detections)
+        mock_we.add_context.assert_any_call(
+            {"parse_data": {"status": "error", "detail": "invalid data size"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_report_service_parse_data_uses_fn_key_on_time_error():
+    with patch(
+        "bot_detector.api_public.src.app.report.wide_event"
+    ) as mock_we:
+        service = ReportService()
+        detections = [_make_detection(ts=int(time.time()) - 30000)]
+        await service.parse_data(detections)
+        mock_we.add_context.assert_any_call(
+            {"parse_data": {"status": "error", "detail": "invalid time"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_report_service_parse_data_uses_fn_key_on_reporter_error():
+    with patch(
+        "bot_detector.api_public.src.app.report.wide_event"
+    ) as mock_we:
+        service = ReportService()
+        detections = [
+            _make_detection(reporter="reporter_a"),
+            _make_detection(reporter="reporter_b"),
+        ]
+        await service.parse_data(detections)
+        mock_we.add_context.assert_any_call(
+            {"parse_data": {"status": "error", "detail": "invalid unique reporter"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_report_service_filter_valid_time_uses_fn_key():
+    with patch(
+        "bot_detector.api_public.src.app.report.wide_event"
+    ) as mock_we:
+        service = ReportService()
+        detections = [_make_detection()]
+        service._filter_valid_time(detections)
+        call_args = mock_we.add_context.call_args[0][0]
+        assert "_filter_valid_time" in call_args
+        assert "stale_report_count" in call_args["_filter_valid_time"]
+        assert "future_report_count" in call_args["_filter_valid_time"]
+
+
+@pytest.mark.asyncio
+async def test_report_service_check_unique_reporter_uses_fn_key():
+    with patch(
+        "bot_detector.api_public.src.app.report.wide_event"
+    ) as mock_we:
+        service = ReportService()
+        detections = [_make_detection()]
+        service._check_unique_reporter(detections)
+        call_args = mock_we.add_context.call_args[0][0]
+        assert "_check_unique_reporter" in call_args
+        assert "reporters" in call_args["_check_unique_reporter"]
+
+
+@pytest.mark.asyncio
+async def test_report_service_send_to_queue_uses_fn_key():
+    with patch(
+        "bot_detector.api_public.src.app.report.wide_event"
+    ) as mock_we:
+        service = ReportService()
+        parsed = MagicMock()
+        parsed.model_dump.return_value = {
+            "reported_id": 1,
+            "reporter_id": 2,
+            "region_id": 0,
+            "x_coord": 0,
+            "y_coord": 0,
+            "z_coord": 0,
+            "ts": int(time.time()),
+            "manual_detect": 0,
+            "on_members_world": 0,
+            "on_pvp_world": 0,
+            "world_number": 500,
+            "equip_ge_value": 0,
+        }
+        producer = AsyncMock()
+        await service.send_to_queue(data=[parsed], producer=producer)
+        for call in mock_we.add_context.call_args_list:
+            call_args = call[0][0]
+            assert "report" not in call_args or "send_to_queue" in call_args
+
+
+@pytest.mark.asyncio
+async def test_player_get_players_kc_adds_entry_and_success_context():
+    with (
+        patch(
+            "bot_detector.api_public.src.api.v2.player.wide_event"
+        ) as mock_we,
+        patch(
+            "bot_detector.api_public.src.api.v2.player.PlayerRepo"
+        ) as mock_repo_cls,
+        patch(
+            "bot_detector.api_public.src.api.v2.player.to_jagex_name",
+            side_effect=lambda n: AsyncMock(_return_value=n)() if False else n,
+        ),
+        patch(
+            "bot_detector.api_public.src.api.v2.player.asyncio"
+        ) as mock_asyncio,
+    ):
+        mock_asyncio.gather = AsyncMock(return_value=["player1"])
+        mock_repo = MagicMock()
+        mock_repo.get_report_score = AsyncMock(return_value=[MagicMock()])
+        mock_repo_cls.return_value = mock_repo
+
+        from bot_detector.api_public.src.api.v2.player import get_players_kc
+
+        await get_players_kc(
+            name=["player1"],
+            session=MagicMock(),
+        )
+
+        calls = [c[0][0] for c in mock_we.add_context.call_args_list]
+        assert any("get_players_kc" in c and "names" in c["get_players_kc"] for c in calls)
+        assert any(
+            "get_players_kc" in c
+            and c["get_players_kc"].get("status") == "success"
+            for c in calls
+        )
+
+
+@pytest.mark.asyncio
+async def test_player_get_feedback_score_adds_entry_and_success_context():
+    with (
+        patch(
+            "bot_detector.api_public.src.api.v2.player.wide_event"
+        ) as mock_we,
+        patch(
+            "bot_detector.api_public.src.api.v2.player.PlayerRepo"
+        ) as mock_repo_cls,
+        patch(
+            "bot_detector.api_public.src.api.v2.player.asyncio"
+        ) as mock_asyncio,
+    ):
+        mock_asyncio.gather = AsyncMock(return_value=["player1"])
+        mock_repo = MagicMock()
+        mock_repo.get_feedback_score = AsyncMock(return_value=[MagicMock()])
+        mock_repo_cls.return_value = mock_repo
+
+        from bot_detector.api_public.src.api.v2.player import get_feedback_score
+
+        await get_feedback_score(
+            name=["player1"],
+            session=MagicMock(),
+        )
+
+        calls = [c[0][0] for c in mock_we.add_context.call_args_list]
+        assert any("get_feedback_score" in c and "names" in c["get_feedback_score"] for c in calls)
+        assert any(
+            "get_feedback_score" in c
+            and c["get_feedback_score"].get("status") == "success"
+            for c in calls
+        )
+
+
+@pytest.mark.asyncio
+async def test_player_get_prediction_adds_entry_context():
+    with (
+        patch(
+            "bot_detector.api_public.src.api.v2.player.wide_event"
+        ) as mock_we,
+        patch(
+            "bot_detector.api_public.src.api.v2.player.PlayerRepo"
+        ) as mock_repo_cls,
+        patch(
+            "bot_detector.api_public.src.api.v2.player.asyncio"
+        ) as mock_asyncio,
+    ):
+        mock_asyncio.gather = AsyncMock(return_value=["player1"])
+        mock_repo = MagicMock()
+        mock_data = MagicMock()
+        mock_repo.get_prediction = AsyncMock(return_value=[mock_data])
+        mock_repo_cls.return_value = mock_repo
+
+        with patch(
+            "bot_detector.api_public.src.api.v2.player.PredictionResponse"
+        ) as mock_resp:
+            mock_resp.from_data.return_value = MagicMock()
+            from bot_detector.api_public.src.api.v2.player import get_prediction
+
+            await get_prediction(
+                name=["player1"],
+                breakdown=True,
+                session=MagicMock(),
+            )
+
+        calls = [c[0][0] for c in mock_we.add_context.call_args_list]
+        assert any(
+            "get_prediction" in c
+            and "names" in c["get_prediction"]
+            and "breakdown" in c["get_prediction"]
+            for c in calls
+        )
+
+
+@pytest.mark.asyncio
+async def test_player_get_prediction_adds_error_context_on_not_found():
+    with (
+        patch(
+            "bot_detector.api_public.src.api.v2.player.wide_event"
+        ) as mock_we,
+        patch(
+            "bot_detector.api_public.src.api.v2.player.PlayerRepo"
+        ) as mock_repo_cls,
+        patch(
+            "bot_detector.api_public.src.api.v2.player.asyncio"
+        ) as mock_asyncio,
+    ):
+        mock_asyncio.gather = AsyncMock(return_value=["player1"])
+        mock_repo = MagicMock()
+        mock_repo.get_prediction = AsyncMock(return_value=[])
+        mock_repo_cls.return_value = mock_repo
+
+        from bot_detector.api_public.src.api.v2.player import get_prediction
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException):
+            await get_prediction(
+                name=["player1"],
+                breakdown=True,
+                session=MagicMock(),
+            )
+
+        calls = [c[0][0] for c in mock_we.add_context.call_args_list]
+        assert any(
+            "get_prediction" in c
+            and c["get_prediction"].get("error") == "Player not found"
+            for c in calls
+        )
+
+
+@pytest.mark.asyncio
+async def test_labels_get_labels_adds_entry_and_success_context():
+    with (
+        patch(
+            "bot_detector.api_public.src.api.v2.labels.wide_event"
+        ) as mock_we,
+        patch(
+            "bot_detector.api_public.src.api.v2.labels.LabelRepo"
+        ) as mock_repo_cls,
+    ):
+        mock_label = MagicMock()
+        mock_label.__dict__ = {"label": "Bot", "id": 1}
+        mock_repo = MagicMock()
+        mock_repo.get_labels = AsyncMock(return_value=[mock_label])
+        mock_repo_cls.return_value = mock_repo
+
+        with patch(
+            "bot_detector.api_public.src.api.v2.labels.LabelResponse"
+        ) as mock_resp:
+            instance = MagicMock()
+            instance.label = "Bot"
+            mock_resp.return_value = instance
+
+            from bot_detector.api_public.src.api.v2.labels import get_labels
+
+            await get_labels(session=MagicMock())
+
+        calls = [c[0][0] for c in mock_we.add_context.call_args_list]
+        assert any("get_labels" in c and c["get_labels"] == {} for c in calls)
+        assert any(
+            "get_labels" in c
+            and c["get_labels"].get("status") == "success"
+            and "labels_count" in c["get_labels"]
+            for c in calls
+        )
+
+
+@pytest.mark.asyncio
+async def test_labels_get_label_by_id_adds_entry_and_success_context():
+    with (
+        patch(
+            "bot_detector.api_public.src.api.v2.labels.wide_event"
+        ) as mock_we,
+        patch(
+            "bot_detector.api_public.src.api.v2.labels.LabelRepo"
+        ) as mock_repo_cls,
+    ):
+        mock_label = MagicMock()
+        mock_label.__dict__ = {"label": "Bot", "id": 1}
+        mock_repo = MagicMock()
+        mock_repo.get_label_by_id = AsyncMock(return_value=mock_label)
+        mock_repo_cls.return_value = mock_repo
+
+        with patch(
+            "bot_detector.api_public.src.api.v2.labels.LabelResponse"
+        ) as mock_resp:
+            instance = MagicMock()
+            instance.label = "Bot"
+            mock_resp.return_value = instance
+
+            from bot_detector.api_public.src.api.v2.labels import get_label_by_id
+
+            await get_label_by_id(label_id=1, session=MagicMock())
+
+        calls = [c[0][0] for c in mock_we.add_context.call_args_list]
+        assert any(
+            "get_label_by_id" in c and c["get_label_by_id"].get("label_id") == 1
+            for c in calls
+        )
+        assert any(
+            "get_label_by_id" in c
+            and c["get_label_by_id"].get("status") == "success"
+            for c in calls
+        )
+
+
+@pytest.mark.asyncio
+async def test_labels_get_label_by_id_not_found_context():
+    with (
+        patch(
+            "bot_detector.api_public.src.api.v2.labels.wide_event"
+        ) as mock_we,
+        patch(
+            "bot_detector.api_public.src.api.v2.labels.LabelRepo"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_label_by_id = AsyncMock(return_value=None)
+        mock_repo_cls.return_value = mock_repo
+
+        from bot_detector.api_public.src.api.v2.labels import get_label_by_id
+
+        result = await get_label_by_id(label_id=99, session=MagicMock())
+
+        assert result is None
+        calls = [c[0][0] for c in mock_we.add_context.call_args_list]
+        assert any(
+            "get_label_by_id" in c
+            and c["get_label_by_id"].get("status") == "not_found"
+            and c["get_label_by_id"].get("label_id") == 99
+            for c in calls
+        )
+
+
+def test_user_read_current_user_adds_called_context():
+    with patch(
+        "bot_detector.api_public.src.api.v2.user.wide_event"
+    ) as mock_we:
+        mock_user = MagicMock()
+        mock_user.username = "testuser"
+        mock_user.token = "testtoken"
+
+        from bot_detector.api_public.src.api.v2.user import read_current_user
+
+        read_current_user(user=mock_user)
+
+        mock_we.add_context.assert_called_once_with(
+            {"read_current_user": {"status": "called"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_report_post_reports_uses_fn_key():
+    with (
+        patch(
+            "bot_detector.api_public.src.api.v2.report.wide_event"
+        ) as mock_we,
+        patch(
+            "bot_detector.api_public.src.api.v2.report.ReportService"
+        ) as mock_svc_cls,
+        patch(
+            "bot_detector.api_public.src.api.v2.report.PlayerRepo"
+        ) as mock_repo_cls,
+        patch(
+            "bot_detector.api_public.src.api.v2.report._get_or_insert_cached",
+            new_callable=AsyncMock,
+        ) as mock_cache,
+    ):
+        from bot_detector.database.api_public import PlayerRepo as RealPlayerRepo
+
+        mock_repo_cls.sanitize_name = RealPlayerRepo.sanitize_name
+
+        detection = _make_detection()
+        mock_svc = MagicMock()
+        mock_svc.parse_data = AsyncMock(return_value=([detection], None))
+        mock_svc.send_to_queue = AsyncMock(return_value=[])
+        mock_svc_cls.return_value = mock_svc
+
+        def _make_player(name, pid):
+            p = MagicMock()
+            p.name = name
+            p.id = pid
+            return p
+
+        mock_cache.side_effect = lambda repo, cache, name: _make_player(
+            name, abs(hash(name))
+        )
+
+        from bot_detector.api_public.src.api.v2.report import post_reports
+
+        await post_reports(
+            detections=[detection],
+            session=MagicMock(),
+            report_producer=MagicMock(),
+        )
+
+        calls = [c[0][0] for c in mock_we.add_context.call_args_list]
+        for call_args in calls:
+            assert "post_reports" in call_args
+            assert "report" not in call_args or "post_reports" in call_args


### PR DESCRIPTION
## Summary
- Standardize all `wide_event.add_context()` calls across `bases/public_api` to use **function-name-keyed** (`_fn`) context nesting instead of the mixed domain-keyed / function-name-keyed patterns
- Add `wide_event` structured logging to `player.py`, `labels.py`, and `user.py` routes that previously had zero business observability
- Remove unused `logger = logging.getLogger(__name__)` declarations from `labels.py`, `user.py`, `feedback.py`, and `app/report.py`

## Changes

| File | Action |
|---|---|
| `app/report.py` | Refactor `"report"` key → `_fn`-keyed, remove unused `logger` |
| `api/v2/report.py` | Refactor `"report"` key → `_fn`-keyed |
| `api/v2/player.py` | Add entry/success/error context for all 3 routes |
| `api/v2/labels.py` | Add entry/success/not_found context, remove unused `logger` |
| `api/v2/user.py` | Add minimal `{"status": "called"}` context (sensitive route), remove unused `logger` |
| `api/v2/feedback.py` | Remove unused `logger` (already Pattern B) |
| `test_wide_event_context.py` | 15 new tests verifying `_fn`-keyed context across all routes |

## Test plan
- [x] All 85 tests pass (`uv run pytest`)
- [x] Ruff linting clean (`uv run ruff check`)
- [x] No new mypy errors introduced
- [x] New test file covers all modified routes with mock assertions on `wide_event.add_context` call args