### PR TITLE
Fix discord error handler crash on rate limits + capture HTTP headers

### DIFF
--- a/bases/bot_detector/discord_bot/cogs/error_handler.py
+++ b/bases/bot_detector/discord_bot/cogs/error_handler.py
@@ -1,8 +1,8 @@
 import logging
-import sys
 import traceback
 
 import aiohttp
+import discord
 from bot_detector.discord_bot.config import Settings
 from bot_detector.discord_bot.dependencies import BotDependencies
 from discord import Webhook
@@ -48,26 +48,51 @@ class errorHandler(commands.Cog):
             await ctx.reply(
                 "You can only message in the allowed channels, in the bot detector guild."
             )
-        else:
-            traceback.print_exception(
-                type(error), error, error.__traceback__, file=sys.stderr
+        elif isinstance(error, discord.HTTPException):
+            headers = dict(error.response.headers)
+            logger.error(
+                {
+                    "error": str(error),
+                    "status": error.response.status,
+                    "discord_code": error.code,
+                    "headers": headers,
+                }
             )
-
-            logger.error({"error": error})
+            if error.response.status == 429:
+                retry = headers.get("Retry-After")
+                wait = f" (try again in {retry}s)" if retry else ""
+                await self._safe_respond(
+                    ctx,
+                    f"The bot is being rate limited by Discord.{wait}"
+                    " Please try again shortly.",
+                )
+            else:
+                await self._safe_respond(ctx, "An error occured.")
+                await self._send_error_webhook(ctx, error)
+        else:
+            logger.error({"error": error}, exc_info=error)
             await self._safe_respond(ctx, "An error occured.")
+            await self._send_error_webhook(ctx, error)
 
-            webhook = Settings().WEBHOOK
-            if webhook:
-                async with aiohttp.ClientSession() as session:
-                    webhook = Webhook.from_url(webhook, session=session)
-                    error_message = (
-                        f"`{ctx.author}` running `{ctx.command}` caused `{error.__class__.__name__}`\n"
-                        f"Message Link: {ctx.message.jump_url}\n"
-                        f"```{''.join(error)}```"
-                    )
-                    error_message = "".join(error_message)
-
-                    await webhook.send(error_message, username="bd-error")
+    async def _send_error_webhook(self, ctx: Context, error: Exception) -> None:
+        webhook_url = Settings().WEBHOOK
+        if not webhook_url:
+            return
+        tb = "".join(
+            traceback.format_exception(type(error), error, error.__traceback__)
+        )
+        error_message = (
+            f"`{ctx.author}` running `{ctx.command}` caused"
+            f" `{error.__class__.__name__}`\n"
+            f"Message Link: {ctx.message.jump_url}\n"
+            f"```\n{tb}\n```"
+        )
+        try:
+            async with aiohttp.ClientSession() as session:
+                webhook = Webhook.from_url(webhook_url, session=session)
+                await webhook.send(error_message, username="bd-error")
+        except Exception as e:
+            logger.error({"msg": "Failed to send error webhook", "error": str(e)})
 
     async def _safe_respond(self, ctx: Context, message: str):
         try:


### PR DESCRIPTION
## Summary
- **Fix the crash** in `on_command_error`: `''.join(error)` raised `TypeError` because `error` is an `Exception`, not an iterable. This caused the handler itself to crash (visible as "Ignoring exception in on_command_error") whenever an unhandled error reached the webhook-reporting path. Now uses `traceback.format_exception` to render a proper traceback.
- **Capture rate-limit headers**: added a dedicated `discord.HTTPException` branch that logs `status`, `discord_code`, and the full response `headers` (`X-RateLimit-*`, `Retry-After`, `X-RateLimit-Scope`, ...) via the codebase's structured `logger.error({...})` style — so rate-limit diagnostics flow into the JSON log stream.
- **Friendly 429 message**: when the bot is rate limited by Discord, users get a clear ephemeral note (including the `Retry-After` wait hint when available) instead of a generic error.
- **Guard the error webhook**: webhook send is now wrapped so a failing error-reporting webhook can never crash the handler again. Extracted into `_send_error_webhook` helper.
- Replaced `traceback.print_exception(..., file=sys.stderr)` with `logger.error({...}, exc_info=error)` so tracebacks flow through the structured logger.

## Root cause
The original 429 from Discord was logged correctly, but the handler then crashed while building the webhook message (`''.join(error)` on a non-iterable `Exception`), which masked the real behavior and produced the noisy `on_command_error` cascade.