### PR TITLE
chore: upgrade discord.py to 2.7.1 + fix rate-limit (429) handling

### DIFF
--- a/bases/bot_detector/discord_bot/bot.py
+++ b/bases/bot_detector/discord_bot/bot.py
@@ -16,6 +16,7 @@ bot = Bot(
     command_prefix=Settings().COMMAND_PREFIX,
     description="busting bots",
     case_insensitive=True,
+    max_ratelimit_timeout=60.0,
     activity=Game("OSRS", type=discord.ActivityType.watching),
     allowed_mentions=AllowedMentions(
         everyone=False,

--- a/bases/bot_detector/discord_bot/cogs/error_handler.py
+++ b/bases/bot_detector/discord_bot/cogs/error_handler.py
@@ -48,27 +48,28 @@ class errorHandler(commands.Cog):
             await ctx.reply(
                 "You can only message in the allowed channels, in the bot detector guild."
             )
+        elif isinstance(error, discord.RateLimited):
+            logger.warning(
+                {
+                    "msg": "Discord rate limit exceeded",
+                    "retry_after": error.retry_after,
+                }
+            )
+            await self._safe_respond(
+                ctx,
+                f"The bot is being rate limited by Discord."
+                f" Please try again in {error.retry_after:.0f}s.",
+            )
         elif isinstance(error, discord.HTTPException):
-            headers = dict(error.response.headers)
             logger.error(
                 {
                     "error": str(error),
                     "status": error.response.status,
                     "discord_code": error.code,
-                    "headers": headers,
                 }
             )
-            if error.response.status == 429:
-                retry = headers.get("Retry-After")
-                wait = f" (try again in {retry}s)" if retry else ""
-                await self._safe_respond(
-                    ctx,
-                    f"The bot is being rate limited by Discord.{wait}"
-                    " Please try again shortly.",
-                )
-            else:
-                await self._safe_respond(ctx, "An error occured.")
-                await self._send_error_webhook(ctx, error)
+            await self._safe_respond(ctx, "An error occured.")
+            await self._send_error_webhook(ctx, error)
         else:
             logger.error({"error": error}, exc_info=error)
             await self._safe_respond(ctx, "An error occured.")
@@ -97,7 +98,7 @@ class errorHandler(commands.Cog):
     async def _safe_respond(self, ctx: Context, message: str):
         try:
             if ctx.interaction and ctx.interaction.response.is_done():
-                await ctx.followup.send(message, ephemeral=True)
+                await ctx.interaction.followup.send(message, ephemeral=True)
             else:
                 await ctx.send(message)
         except Exception:

--- a/bases/bot_detector/discord_bot/cogs/error_handler.py
+++ b/bases/bot_detector/discord_bot/cogs/error_handler.py
@@ -61,15 +61,28 @@ class errorHandler(commands.Cog):
                 f" Please try again in {error.retry_after:.0f}s.",
             )
         elif isinstance(error, discord.HTTPException):
-            logger.error(
-                {
-                    "error": str(error),
-                    "status": error.response.status,
-                    "discord_code": error.code,
-                }
-            )
-            await self._safe_respond(ctx, "An error occured.")
-            await self._send_error_webhook(ctx, error)
+            if error.status == 429:
+                logger.warning(
+                    {
+                        "msg": "Discord global rate limit exceeded",
+                        "status": error.status,
+                    }
+                )
+                await self._safe_respond(
+                    ctx,
+                    "The bot is being rate limited by Discord."
+                    " Please try again shortly.",
+                )
+            else:
+                logger.error(
+                    {
+                        "error": str(error),
+                        "status": error.status,
+                        "discord_code": error.code,
+                    }
+                )
+                await self._safe_respond(ctx, "An error occured.")
+                await self._send_error_webhook(ctx, error)
         else:
             logger.error({"error": error}, exc_info=error)
             await self._safe_respond(ctx, "An error occured.")

--- a/bases/bot_detector/discord_bot/core.py
+++ b/bases/bot_detector/discord_bot/core.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 
 import discord
-from aiohttp import ClientResponse
 from bot_detector.discord_bot import bot
 from bot_detector.discord_bot.config import Settings
 
@@ -18,29 +17,21 @@ async def run_async():
     while True:
         try:
             await bot.bot.start(token=settings.DISCORD_TOKEN)
+        except discord.RateLimited as e:
+            logger.warning(
+                f"Discord rate limit exceeded. Restarting in {e.retry_after}s..."
+            )
+            await asyncio.sleep(e.retry_after)
+            continue
         except discord.HTTPException as e:
             logger.error(
                 {
                     "msg": "Discord HTTP Exception:",
-                    "headers": dict(e.response.headers),
+                    "status": e.status,
                     "error": str(e),
                 }
             )
-            if not isinstance(e.response, ClientResponse):
-                break
-            if e.response.status == 429:
-                headers = dict(e.response.headers)
-                sleep_time = headers.get("Retry-After", 60)
-                sleep_time = (
-                    sleep_time
-                    if isinstance(sleep_time, (int, float))
-                    else float(sleep_time)
-                )
-                logger.error(
-                    f"Discord API rate limit exceeded. Retrying in {sleep_time} seconds..."
-                )
-                await asyncio.sleep(sleep_time)
-            raise e
+            raise
         break
 
 

--- a/projects/discord_bot/pyproject.toml
+++ b/projects/discord_bot/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 requires-python = ">=3.11"
 
 dependencies = [
-    "discord-py>=2.2.2",
+    "discord-py>=2.7.1",
     "matplotlib>=3.10.0",
     "seaborn>=0.13.0",
     "sqlalchemy==2.0.44",

--- a/projects/discord_bot/uv.lock
+++ b/projects/discord_bot/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -364,7 +363,7 @@ dependencies = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "asyncmy", specifier = "==0.2.11" },
-    { name = "discord-py", specifier = ">=2.2.2" },
+    { name = "discord-py", specifier = ">=2.7.1" },
     { name = "matplotlib", specifier = ">=3.10.0" },
     { name = "orjson", specifier = ">=3.11.8" },
     { name = "prometheus-client", specifier = "==0.22.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "asyncmy==0.2.11",
     "boto3==1.40.34",
     "cryptography==46.0.3",
-    "discord-py>=2.2.2",
+    "discord-py>=2.7.1",
     "fastapi==0.115.12",
     "jinja2==3.1.6",
     "matplotlib>=3.10.0",

--- a/test/bases/bot_detector/discord_bot/test_core.py
+++ b/test/bases/bot_detector/discord_bot/test_core.py
@@ -1,0 +1,83 @@
+import os
+from unittest.mock import AsyncMock, patch
+
+import discord
+import pytest
+
+os.environ.setdefault("DISCORD_TOKEN", "test-token")
+os.environ.setdefault("OSRS_ITEMS_USER_AGENT", "test-agent")
+
+from bot_detector.discord_bot import core
+
+
+@pytest.mark.asyncio
+async def test_ratelimited_sleeps_and_retries():
+    """RateLimited should sleep retry_after seconds then retry the loop."""
+    call_count = 0
+
+    async def fake_start(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise discord.RateLimited(retry_after=0.01)
+
+    with (
+        patch.object(core.bot.bot, "start", side_effect=fake_start),
+        patch.object(core.asyncio, "sleep", new_callable=AsyncMock) as mock_sleep,
+    ):
+        await core.run_async()
+
+    assert call_count == 2
+    mock_sleep.assert_awaited_once_with(0.01)
+
+
+@pytest.mark.asyncio
+async def test_http_exception_reraises():
+    """Non-rate-limit HTTPException should re-raise, not loop."""
+
+    async def fake_start(**kwargs):
+        raise discord.HTTPException(
+            response=type(
+                "FakeResponse",
+                (),
+                {"status": 500, "reason": "Internal Server Error", "headers": {}},
+            )(),
+            message="Internal error",
+        )
+
+    with (
+        patch.object(core.bot.bot, "start", side_effect=fake_start),
+        pytest.raises(discord.HTTPException),
+    ):
+        await core.run_async()
+
+
+@pytest.mark.asyncio
+async def test_clean_start_exits_loop():
+    """If bot.start returns cleanly, run_async should exit without retrying."""
+
+    async def fake_start(**kwargs):
+        pass
+
+    with patch.object(core.bot.bot, "start", side_effect=fake_start):
+        await core.run_async()
+
+
+@pytest.mark.asyncio
+async def test_ratelimited_does_not_reraise():
+    """RateLimited should be swallowed (retry), not propagated to caller."""
+    call_count = 0
+
+    async def fake_start(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise discord.RateLimited(retry_after=0.01)
+
+    with (
+        patch.object(core.bot.bot, "start", side_effect=fake_start),
+        patch.object(core.asyncio, "sleep", new_callable=AsyncMock),
+    ):
+        await core.run_async()
+
+    assert call_count == 2

--- a/test/bases/bot_detector/discord_bot/test_error_handler.py
+++ b/test/bases/bot_detector/discord_bot/test_error_handler.py
@@ -81,6 +81,24 @@ async def test_http_exception_triggers_webhook():
 
 
 @pytest.mark.asyncio
+async def test_global_429_does_not_trigger_webhook():
+    """Global rate limits come as HTTPException 429, not RateLimited."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    error = _make_http_exception(status=429)
+
+    with patch.object(
+        cog, "_send_error_webhook", new_callable=AsyncMock
+    ) as mock_webhook:
+        await cog.on_command_error(ctx, error)
+
+    mock_webhook.assert_not_awaited()
+    ctx.send.assert_awaited_once()
+    assert "rate limited" in ctx.send.call_args.args[0].lower()
+
+
+@pytest.mark.asyncio
 async def test_safe_respond_uses_interaction_followup():
     """When interaction is done, should use interaction.followup.send."""
     cog = _make_cog()

--- a/test/bases/bot_detector/discord_bot/test_error_handler.py
+++ b/test/bases/bot_detector/discord_bot/test_error_handler.py
@@ -1,0 +1,119 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+os.environ.setdefault("DISCORD_TOKEN", "test-token")
+os.environ.setdefault("OSRS_ITEMS_USER_AGENT", "test-agent")
+
+from bot_detector.discord_bot.cogs.error_handler import errorHandler
+
+
+def _make_cog() -> errorHandler:
+    bot = MagicMock()
+    deps = MagicMock()
+    return errorHandler(bot=bot, deps=deps)
+
+
+def _make_ctx() -> AsyncMock:
+    ctx = AsyncMock()
+    ctx.author.name = "test_user"
+    ctx.author.id = 12345
+    ctx.command = SimpleNamespace()
+    ctx.cog = None
+    ctx.message = MagicMock()
+    ctx.message.jump_url = "http://discord.com/jump/123"
+    ctx.interaction = None
+    return ctx
+
+
+def _make_http_exception(status: int = 500) -> discord.HTTPException:
+    response = MagicMock()
+    response.status = status
+    response.headers = {}
+    return discord.HTTPException(response=response, message="test error")
+
+
+@pytest.mark.asyncio
+async def test_ratelimited_responds_with_retry_after():
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    error = discord.RateLimited(retry_after=120.0)
+
+    await cog.on_command_error(ctx, error)
+
+    ctx.send.assert_awaited_once()
+    msg = ctx.send.call_args.args[0]
+    assert "120s" in msg
+
+
+@pytest.mark.asyncio
+async def test_ratelimited_does_not_trigger_webhook():
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    error = discord.RateLimited(retry_after=60.0)
+
+    with patch.object(
+        cog, "_send_error_webhook", new_callable=AsyncMock
+    ) as mock_webhook:
+        await cog.on_command_error(ctx, error)
+
+    mock_webhook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_exception_triggers_webhook():
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    error = _make_http_exception(status=500)
+
+    with patch.object(
+        cog, "_send_error_webhook", new_callable=AsyncMock
+    ) as mock_webhook:
+        await cog.on_command_error(ctx, error)
+
+    mock_webhook.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_safe_respond_uses_interaction_followup():
+    """When interaction is done, should use interaction.followup.send."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+    ctx.interaction = MagicMock()
+    ctx.interaction.response.is_done.return_value = True
+    ctx.interaction.followup = AsyncMock()
+
+    await cog._safe_respond(ctx, "test message")
+
+    ctx.interaction.followup.send.assert_awaited_once_with(
+        "test message", ephemeral=True
+    )
+    ctx.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_safe_respond_uses_ctx_send_when_no_interaction():
+    """When no interaction, should fall back to ctx.send."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    await cog._safe_respond(ctx, "test message")
+
+    ctx.send.assert_awaited_once_with("test message")
+
+
+@pytest.mark.asyncio
+async def test_safe_respond_swallows_send_failure():
+    cog = _make_cog()
+    ctx = _make_ctx()
+    ctx.send.side_effect = discord.HTTPException(
+        response=MagicMock(status=404, headers={}), message="not found"
+    )
+
+    await cog._safe_respond(ctx, "test message")

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,9 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.13.*'",
     "python_full_version < '3.12'",
 ]
 
@@ -218,6 +218,62 @@ wheels = [
 ]
 
 [[package]]
+name = "audioop-lts"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/53/946db57842a50b2da2e0c1e34bd37f36f5aadba1a929a3971c5d7841dbca/audioop_lts-0.2.2.tar.gz", hash = "sha256:64d0c62d88e67b98a1a5e71987b7aa7b5bcffc7dcee65b635823dbdd0a8dbbd0", size = 30686 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/d4/94d277ca941de5a507b07f0b592f199c22454eeaec8f008a286b3fbbacd6/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd3d4602dc64914d462924a08c1a9816435a2155d74f325853c1f1ac3b2d9800", size = 46523 },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/656d1c2da4b555920ce4177167bfeb8623d98765594af59702c8873f60ec/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:550c114a8df0aafe9a05442a1162dfc8fec37e9af1d625ae6060fed6e756f303", size = 27455 },
+    { url = "https://files.pythonhosted.org/packages/1b/83/ea581e364ce7b0d41456fb79d6ee0ad482beda61faf0cab20cbd4c63a541/audioop_lts-0.2.2-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a13dc409f2564de15dd68be65b462ba0dde01b19663720c68c1140c782d1d75", size = 26997 },
+    { url = "https://files.pythonhosted.org/packages/b8/3b/e8964210b5e216e5041593b7d33e97ee65967f17c282e8510d19c666dab4/audioop_lts-0.2.2-cp313-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:51c916108c56aa6e426ce611946f901badac950ee2ddaf302b7ed35d9958970d", size = 85844 },
+    { url = "https://files.pythonhosted.org/packages/c7/2e/0a1c52faf10d51def20531a59ce4c706cb7952323b11709e10de324d6493/audioop_lts-0.2.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47eba38322370347b1c47024defbd36374a211e8dd5b0dcbce7b34fdb6f8847b", size = 85056 },
+    { url = "https://files.pythonhosted.org/packages/75/e8/cd95eef479656cb75ab05dfece8c1f8c395d17a7c651d88f8e6e291a63ab/audioop_lts-0.2.2-cp313-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba7c3a7e5f23e215cb271516197030c32aef2e754252c4c70a50aaff7031a2c8", size = 93892 },
+    { url = "https://files.pythonhosted.org/packages/5c/1e/a0c42570b74f83efa5cca34905b3eef03f7ab09fe5637015df538a7f3345/audioop_lts-0.2.2-cp313-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:def246fe9e180626731b26e89816e79aae2276f825420a07b4a647abaa84becc", size = 96660 },
+    { url = "https://files.pythonhosted.org/packages/50/d5/8a0ae607ca07dbb34027bac8db805498ee7bfecc05fd2c148cc1ed7646e7/audioop_lts-0.2.2-cp313-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e160bf9df356d841bb6c180eeeea1834085464626dc1b68fa4e1d59070affdc3", size = 79143 },
+    { url = "https://files.pythonhosted.org/packages/12/17/0d28c46179e7910bfb0bb62760ccb33edb5de973052cb2230b662c14ca2e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4b4cd51a57b698b2d06cb9993b7ac8dfe89a3b2878e96bc7948e9f19ff51dba6", size = 84313 },
+    { url = "https://files.pythonhosted.org/packages/84/ba/bd5d3806641564f2024e97ca98ea8f8811d4e01d9b9f9831474bc9e14f9e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4a53aa7c16a60a6857e6b0b165261436396ef7293f8b5c9c828a3a203147ed4a", size = 93044 },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/435ce8d5642f1f7679540d1e73c1c42d933331c0976eb397d1717d7f01a3/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:3fc38008969796f0f689f1453722a0f463da1b8a6fbee11987830bfbb664f623", size = 78766 },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/b909e76b606cbfd53875693ec8c156e93e15a1366a012f0b7e4fb52d3c34/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:15ab25dd3e620790f40e9ead897f91e79c0d3ce65fe193c8ed6c26cffdd24be7", size = 87640 },
+    { url = "https://files.pythonhosted.org/packages/30/e7/8f1603b4572d79b775f2140d7952f200f5e6c62904585d08a01f0a70393a/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:03f061a1915538fd96272bac9551841859dbb2e3bf73ebe4a23ef043766f5449", size = 86052 },
+    { url = "https://files.pythonhosted.org/packages/b5/96/c37846df657ccdda62ba1ae2b6534fa90e2e1b1742ca8dcf8ebd38c53801/audioop_lts-0.2.2-cp313-abi3-win32.whl", hash = "sha256:3bcddaaf6cc5935a300a8387c99f7a7fbbe212a11568ec6cf6e4bc458c048636", size = 26185 },
+    { url = "https://files.pythonhosted.org/packages/34/a5/9d78fdb5b844a83da8a71226c7bdae7cc638861085fff7a1d707cb4823fa/audioop_lts-0.2.2-cp313-abi3-win_amd64.whl", hash = "sha256:a2c2a947fae7d1062ef08c4e369e0ba2086049a5e598fda41122535557012e9e", size = 30503 },
+    { url = "https://files.pythonhosted.org/packages/34/25/20d8fde083123e90c61b51afb547bb0ea7e77bab50d98c0ab243d02a0e43/audioop_lts-0.2.2-cp313-abi3-win_arm64.whl", hash = "sha256:5f93a5db13927a37d2d09637ccca4b2b6b48c19cd9eda7b17a2e9f77edee6a6f", size = 24173 },
+    { url = "https://files.pythonhosted.org/packages/58/a7/0a764f77b5c4ac58dc13c01a580f5d32ae8c74c92020b961556a43e26d02/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:73f80bf4cd5d2ca7814da30a120de1f9408ee0619cc75da87d0641273d202a09", size = 47096 },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/ebebedde1a18848b085ad0fa54b66ceb95f1f94a3fc04f1cd1b5ccb0ed42/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:106753a83a25ee4d6f473f2be6b0966fc1c9af7e0017192f5531a3e7463dce58", size = 27748 },
+    { url = "https://files.pythonhosted.org/packages/cb/6e/11ca8c21af79f15dbb1c7f8017952ee8c810c438ce4e2b25638dfef2b02c/audioop_lts-0.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fbdd522624141e40948ab3e8cdae6e04c748d78710e9f0f8d4dae2750831de19", size = 27329 },
+    { url = "https://files.pythonhosted.org/packages/84/52/0022f93d56d85eec5da6b9da6a958a1ef09e80c39f2cc0a590c6af81dcbb/audioop_lts-0.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:143fad0311e8209ece30a8dbddab3b65ab419cbe8c0dde6e8828da25999be911", size = 92407 },
+    { url = "https://files.pythonhosted.org/packages/87/1d/48a889855e67be8718adbc7a01f3c01d5743c325453a5e81cf3717664aad/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfbbc74ec68a0fd08cfec1f4b5e8cca3d3cd7de5501b01c4b5d209995033cde9", size = 91811 },
+    { url = "https://files.pythonhosted.org/packages/98/a6/94b7213190e8077547ffae75e13ed05edc488653c85aa5c41472c297d295/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cfcac6aa6f42397471e4943e0feb2244549db5c5d01efcd02725b96af417f3fe", size = 100470 },
+    { url = "https://files.pythonhosted.org/packages/e9/e9/78450d7cb921ede0cfc33426d3a8023a3bda755883c95c868ee36db8d48d/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:752d76472d9804ac60f0078c79cdae8b956f293177acd2316cd1e15149aee132", size = 103878 },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/cd5439aad4f3e34ae1ee852025dc6aa8f67a82b97641e390bf7bd9891d3e/audioop_lts-0.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:83c381767e2cc10e93e40281a04852facc4cd9334550e0f392f72d1c0a9c5753", size = 84867 },
+    { url = "https://files.pythonhosted.org/packages/68/4b/9d853e9076c43ebba0d411e8d2aa19061083349ac695a7d082540bad64d0/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c0022283e9556e0f3643b7c3c03f05063ca72b3063291834cca43234f20c60bb", size = 90001 },
+    { url = "https://files.pythonhosted.org/packages/58/26/4bae7f9d2f116ed5593989d0e521d679b0d583973d203384679323d8fa85/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a2d4f1513d63c795e82948e1305f31a6d530626e5f9f2605408b300ae6095093", size = 99046 },
+    { url = "https://files.pythonhosted.org/packages/b2/67/a9f4fb3e250dda9e9046f8866e9fa7d52664f8985e445c6b4ad6dfb55641/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c9c8e68d8b4a56fda8c025e538e639f8c5953f5073886b596c93ec9b620055e7", size = 84788 },
+    { url = "https://files.pythonhosted.org/packages/70/f7/3de86562db0121956148bcb0fe5b506615e3bcf6e63c4357a612b910765a/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:96f19de485a2925314f5020e85911fb447ff5fbef56e8c7c6927851b95533a1c", size = 94472 },
+    { url = "https://files.pythonhosted.org/packages/f1/32/fd772bf9078ae1001207d2df1eef3da05bea611a87dd0e8217989b2848fa/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e541c3ef484852ef36545f66209444c48b28661e864ccadb29daddb6a4b8e5f5", size = 92279 },
+    { url = "https://files.pythonhosted.org/packages/4f/41/affea7181592ab0ab560044632571a38edaf9130b84928177823fbf3176a/audioop_lts-0.2.2-cp313-cp313t-win32.whl", hash = "sha256:d5e73fa573e273e4f2e5ff96f9043858a5e9311e94ffefd88a3186a910c70917", size = 26568 },
+    { url = "https://files.pythonhosted.org/packages/28/2b/0372842877016641db8fc54d5c88596b542eec2f8f6c20a36fb6612bf9ee/audioop_lts-0.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9191d68659eda01e448188f60364c7763a7ca6653ed3f87ebb165822153a8547", size = 30942 },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/baf2b9cc7e96c179bb4a54f30fcd83e6ecb340031bde68f486403f943768/audioop_lts-0.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c174e322bb5783c099aaf87faeb240c8d210686b04bd61dfd05a8e5a83d88969", size = 24603 },
+    { url = "https://files.pythonhosted.org/packages/5c/73/413b5a2804091e2c7d5def1d618e4837f1cb82464e230f827226278556b7/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:f9ee9b52f5f857fbaf9d605a360884f034c92c1c23021fb90b2e39b8e64bede6", size = 47104 },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/daa3308dc6593944410c2c68306a5e217f5c05b70a12e70228e7dd42dc5c/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:49ee1a41738a23e98d98b937a0638357a2477bc99e61b0f768a8f654f45d9b7a", size = 27754 },
+    { url = "https://files.pythonhosted.org/packages/4e/86/c2e0f627168fcf61781a8f72cab06b228fe1da4b9fa4ab39cfb791b5836b/audioop_lts-0.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5b00be98ccd0fc123dcfad31d50030d25fcf31488cde9e61692029cd7394733b", size = 27332 },
+    { url = "https://files.pythonhosted.org/packages/c7/bd/35dce665255434f54e5307de39e31912a6f902d4572da7c37582809de14f/audioop_lts-0.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6d2e0f9f7a69403e388894d4ca5ada5c47230716a03f2847cfc7bd1ecb589d6", size = 92396 },
+    { url = "https://files.pythonhosted.org/packages/2d/d2/deeb9f51def1437b3afa35aeb729d577c04bcd89394cb56f9239a9f50b6f/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9b0b8a03ef474f56d1a842af1a2e01398b8f7654009823c6d9e0ecff4d5cfbf", size = 91811 },
+    { url = "https://files.pythonhosted.org/packages/76/3b/09f8b35b227cee28cc8231e296a82759ed80c1a08e349811d69773c48426/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b267b70747d82125f1a021506565bdc5609a2b24bcb4773c16d79d2bb260bbd", size = 100483 },
+    { url = "https://files.pythonhosted.org/packages/0b/15/05b48a935cf3b130c248bfdbdea71ce6437f5394ee8533e0edd7cfd93d5e/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0337d658f9b81f4cd0fdb1f47635070cc084871a3d4646d9de74fdf4e7c3d24a", size = 103885 },
+    { url = "https://files.pythonhosted.org/packages/83/80/186b7fce6d35b68d3d739f228dc31d60b3412105854edb975aa155a58339/audioop_lts-0.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:167d3b62586faef8b6b2275c3218796b12621a60e43f7e9d5845d627b9c9b80e", size = 84899 },
+    { url = "https://files.pythonhosted.org/packages/49/89/c78cc5ac6cb5828f17514fb12966e299c850bc885e80f8ad94e38d450886/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0d9385e96f9f6da847f4d571ce3cb15b5091140edf3db97276872647ce37efd7", size = 89998 },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/6401888d0c010e586c2ca50fce4c903d70a6bb55928b16cfbdfd957a13da/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:48159d96962674eccdca9a3df280e864e8ac75e40a577cc97c5c42667ffabfc5", size = 99046 },
+    { url = "https://files.pythonhosted.org/packages/de/f8/c874ca9bb447dae0e2ef2e231f6c4c2b0c39e31ae684d2420b0f9e97ee68/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8fefe5868cd082db1186f2837d64cfbfa78b548ea0d0543e9b28935ccce81ce9", size = 84843 },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/0323e66f3daebc13fd46b36b30c3be47e3fc4257eae44f1e77eb828c703f/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:58cf54380c3884fb49fdd37dfb7a772632b6701d28edd3e2904743c5e1773602", size = 94490 },
+    { url = "https://files.pythonhosted.org/packages/98/6b/acc7734ac02d95ab791c10c3f17ffa3584ccb9ac5c18fd771c638ed6d1f5/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:088327f00488cdeed296edd9215ca159f3a5a5034741465789cad403fcf4bec0", size = 92297 },
+    { url = "https://files.pythonhosted.org/packages/13/c3/c3dc3f564ce6877ecd2a05f8d751b9b27a8c320c2533a98b0c86349778d0/audioop_lts-0.2.2-cp314-cp314t-win32.whl", hash = "sha256:068aa17a38b4e0e7de771c62c60bbca2455924b67a8814f3b0dee92b5820c0b3", size = 27331 },
+    { url = "https://files.pythonhosted.org/packages/72/bb/b4608537e9ffcb86449091939d52d24a055216a36a8bf66b936af8c3e7ac/audioop_lts-0.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a5bf613e96f49712073de86f20dbdd4014ca18efd4d34ed18c75bd808337851b", size = 31697 },
+    { url = "https://files.pythonhosted.org/packages/f6/22/91616fe707a5c5510de2cac9b046a30defe7007ba8a0c04f9c08f27df312/audioop_lts-0.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:b492c3b040153e68b9fdaff5913305aaaba5bb433d8a7f73d5cf6a64ed3cc1dd", size = 25206 },
+]
+
+[[package]]
 name = "bot-detector"
 version = "0.1.0"
 source = { editable = "." }
@@ -269,7 +325,7 @@ requires-dist = [
     { name = "asyncmy", specifier = "==0.2.11" },
     { name = "boto3", specifier = "==1.40.34" },
     { name = "cryptography", specifier = "==46.0.3" },
-    { name = "discord-py", specifier = ">=2.2.2" },
+    { name = "discord-py", specifier = ">=2.7.1" },
     { name = "fastapi", specifier = "==0.115.12" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "matplotlib", specifier = ">=3.10.0" },
@@ -471,7 +527,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -719,14 +775,15 @@ wheels = [
 
 [[package]]
 name = "discord-py"
-version = "2.2.2"
+version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/0f/ceea1cd9f27c1a8a457946cfd6b7b33de75e4e43a4a81679ea1ea81f41f5/discord.py-2.2.2.tar.gz", hash = "sha256:b9944056bcb5711b2d04088848fd004466cf117c15c84fa798bf55470f28275f", size = 973647 }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/57/9a2d9abdabdc9db8ef28ce0cf4129669e1c8717ba28d607b5ba357c4de3b/discord_py-2.7.1.tar.gz", hash = "sha256:24d5e6a45535152e4b98148a9dd6b550d25dc2c9fb41b6d670319411641249da", size = 1106326 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/e5/291c0312640b568fbe1d276e41d94f377d21255117b47a8da39c339790fb/discord.py-2.2.2-py3-none-any.whl", hash = "sha256:38fc52a784727b8e5e5749267089400035b187a009028eddfabeb182abcc6d52", size = 1079863 },
+    { url = "https://files.pythonhosted.org/packages/f7/a7/17208c3b3f92319e7fad259f1c6d5a5baf8fd0654c54846ced329f83c3eb/discord_py-2.7.1-py3-none-any.whl", hash = "sha256:849dca2c63b171146f3a7f3f8acc04248098e9e6203412ce3cf2745f284f7439", size = 1227550 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `discord-py` floor from `>=2.2.2` to `>=2.7.1` in both the workspace root and `projects/discord_bot` `pyproject.toml`, and re-locks both `uv.lock` files.

## Why
There was **version drift**: `projects/discord_bot/uv.lock` already resolved `discord-py` to `2.7.1`, but the workspace root `uv.lock` was still pinned at `2.2.2`. This aligns both environments on `2.7.1`. Additionally, `discord.py` 2.7.1 pulls in `audioop-lts` (needed because `audioop` was removed from the stdlib in Python 3.13).

## Changes
- `pyproject.toml`: `discord-py>=2.2.2` -> `discord-py>=2.7.1`
- `projects/discord_bot/pyproject.toml`: same bump
- `uv.lock`: resolved `discord-py` 2.2.2 -> 2.7.1 (added `audioop-lts`)
- `projects/discord_bot/uv.lock`: refreshed (already at 2.7.1)

## Verification
- `uv run pytest test/bases/bot_detector/discord_bot` -> **31 passed**
- `uv run ruff check bases/bot_detector/discord_bot` -> clean
- `uv run mypy bases/bot_detector/discord_bot` -> **no new errors** vs. baseline (50 pre-existing errors, identical on both 2.2.2 and 2.7.1; CI does not gate the bot on mypy)

## Notes
- The existing discord_bot CI workflow builds/deploys only and does not run tests or type checks, so there is no existing gate to regress.