### PR TITLE
fix: handle Discord 429 rate limits properly

### DIFF
--- a/bases/bot_detector/discord_bot/bot.py
+++ b/bases/bot_detector/discord_bot/bot.py
@@ -16,6 +16,7 @@ bot = Bot(
     command_prefix=Settings().COMMAND_PREFIX,
     description="busting bots",
     case_insensitive=True,
+    max_ratelimit_timeout=60.0,
     activity=Game("OSRS", type=discord.ActivityType.watching),
     allowed_mentions=AllowedMentions(
         everyone=False,

--- a/bases/bot_detector/discord_bot/cogs/error_handler.py
+++ b/bases/bot_detector/discord_bot/cogs/error_handler.py
@@ -48,27 +48,28 @@ class errorHandler(commands.Cog):
             await ctx.reply(
                 "You can only message in the allowed channels, in the bot detector guild."
             )
+        elif isinstance(error, discord.RateLimited):
+            logger.warning(
+                {
+                    "msg": "Discord rate limit exceeded",
+                    "retry_after": error.retry_after,
+                }
+            )
+            await self._safe_respond(
+                ctx,
+                f"The bot is being rate limited by Discord."
+                f" Please try again in {error.retry_after:.0f}s.",
+            )
         elif isinstance(error, discord.HTTPException):
-            headers = dict(error.response.headers)
             logger.error(
                 {
                     "error": str(error),
                     "status": error.response.status,
                     "discord_code": error.code,
-                    "headers": headers,
                 }
             )
-            if error.response.status == 429:
-                retry = headers.get("Retry-After")
-                wait = f" (try again in {retry}s)" if retry else ""
-                await self._safe_respond(
-                    ctx,
-                    f"The bot is being rate limited by Discord.{wait}"
-                    " Please try again shortly.",
-                )
-            else:
-                await self._safe_respond(ctx, "An error occured.")
-                await self._send_error_webhook(ctx, error)
+            await self._safe_respond(ctx, "An error occured.")
+            await self._send_error_webhook(ctx, error)
         else:
             logger.error({"error": error}, exc_info=error)
             await self._safe_respond(ctx, "An error occured.")
@@ -97,7 +98,7 @@ class errorHandler(commands.Cog):
     async def _safe_respond(self, ctx: Context, message: str):
         try:
             if ctx.interaction and ctx.interaction.response.is_done():
-                await ctx.followup.send(message, ephemeral=True)
+                await ctx.interaction.followup.send(message, ephemeral=True)
             else:
                 await ctx.send(message)
         except Exception:

--- a/bases/bot_detector/discord_bot/core.py
+++ b/bases/bot_detector/discord_bot/core.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 
 import discord
-from aiohttp import ClientResponse
 from bot_detector.discord_bot import bot
 from bot_detector.discord_bot.config import Settings
 
@@ -18,29 +17,21 @@ async def run_async():
     while True:
         try:
             await bot.bot.start(token=settings.DISCORD_TOKEN)
+        except discord.RateLimited as e:
+            logger.warning(
+                f"Discord rate limit exceeded. Restarting in {e.retry_after}s..."
+            )
+            await asyncio.sleep(e.retry_after)
+            continue
         except discord.HTTPException as e:
             logger.error(
                 {
                     "msg": "Discord HTTP Exception:",
-                    "headers": dict(e.response.headers),
+                    "status": e.status,
                     "error": str(e),
                 }
             )
-            if not isinstance(e.response, ClientResponse):
-                break
-            if e.response.status == 429:
-                headers = dict(e.response.headers)
-                sleep_time = headers.get("Retry-After", 60)
-                sleep_time = (
-                    sleep_time
-                    if isinstance(sleep_time, (int, float))
-                    else float(sleep_time)
-                )
-                logger.error(
-                    f"Discord API rate limit exceeded. Retrying in {sleep_time} seconds..."
-                )
-                await asyncio.sleep(sleep_time)
-            raise e
+            raise
         break
 
 

--- a/test/bases/bot_detector/discord_bot/test_core.py
+++ b/test/bases/bot_detector/discord_bot/test_core.py
@@ -1,0 +1,83 @@
+import os
+from unittest.mock import AsyncMock, patch
+
+import discord
+import pytest
+
+os.environ.setdefault("DISCORD_TOKEN", "test-token")
+os.environ.setdefault("OSRS_ITEMS_USER_AGENT", "test-agent")
+
+from bot_detector.discord_bot import core
+
+
+@pytest.mark.asyncio
+async def test_ratelimited_sleeps_and_retries():
+    """RateLimited should sleep retry_after seconds then retry the loop."""
+    call_count = 0
+
+    async def fake_start(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise discord.RateLimited(retry_after=0.01)
+
+    with (
+        patch.object(core.bot.bot, "start", side_effect=fake_start),
+        patch.object(core.asyncio, "sleep", new_callable=AsyncMock) as mock_sleep,
+    ):
+        await core.run_async()
+
+    assert call_count == 2
+    mock_sleep.assert_awaited_once_with(0.01)
+
+
+@pytest.mark.asyncio
+async def test_http_exception_reraises():
+    """Non-rate-limit HTTPException should re-raise, not loop."""
+
+    async def fake_start(**kwargs):
+        raise discord.HTTPException(
+            response=type(
+                "FakeResponse",
+                (),
+                {"status": 500, "reason": "Internal Server Error", "headers": {}},
+            )(),
+            message="Internal error",
+        )
+
+    with (
+        patch.object(core.bot.bot, "start", side_effect=fake_start),
+        pytest.raises(discord.HTTPException),
+    ):
+        await core.run_async()
+
+
+@pytest.mark.asyncio
+async def test_clean_start_exits_loop():
+    """If bot.start returns cleanly, run_async should exit without retrying."""
+
+    async def fake_start(**kwargs):
+        pass
+
+    with patch.object(core.bot.bot, "start", side_effect=fake_start):
+        await core.run_async()
+
+
+@pytest.mark.asyncio
+async def test_ratelimited_does_not_reraise():
+    """RateLimited should be swallowed (retry), not propagated to caller."""
+    call_count = 0
+
+    async def fake_start(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise discord.RateLimited(retry_after=0.01)
+
+    with (
+        patch.object(core.bot.bot, "start", side_effect=fake_start),
+        patch.object(core.asyncio, "sleep", new_callable=AsyncMock),
+    ):
+        await core.run_async()
+
+    assert call_count == 2

--- a/test/bases/bot_detector/discord_bot/test_error_handler.py
+++ b/test/bases/bot_detector/discord_bot/test_error_handler.py
@@ -1,0 +1,119 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+os.environ.setdefault("DISCORD_TOKEN", "test-token")
+os.environ.setdefault("OSRS_ITEMS_USER_AGENT", "test-agent")
+
+from bot_detector.discord_bot.cogs.error_handler import errorHandler
+
+
+def _make_cog() -> errorHandler:
+    bot = MagicMock()
+    deps = MagicMock()
+    return errorHandler(bot=bot, deps=deps)
+
+
+def _make_ctx() -> AsyncMock:
+    ctx = AsyncMock()
+    ctx.author.name = "test_user"
+    ctx.author.id = 12345
+    ctx.command = SimpleNamespace()
+    ctx.cog = None
+    ctx.message = MagicMock()
+    ctx.message.jump_url = "http://discord.com/jump/123"
+    ctx.interaction = None
+    return ctx
+
+
+def _make_http_exception(status: int = 500) -> discord.HTTPException:
+    response = MagicMock()
+    response.status = status
+    response.headers = {}
+    return discord.HTTPException(response=response, message="test error")
+
+
+@pytest.mark.asyncio
+async def test_ratelimited_responds_with_retry_after():
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    error = discord.RateLimited(retry_after=120.0)
+
+    await cog.on_command_error(ctx, error)
+
+    ctx.send.assert_awaited_once()
+    msg = ctx.send.call_args.args[0]
+    assert "120s" in msg
+
+
+@pytest.mark.asyncio
+async def test_ratelimited_does_not_trigger_webhook():
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    error = discord.RateLimited(retry_after=60.0)
+
+    with patch.object(
+        cog, "_send_error_webhook", new_callable=AsyncMock
+    ) as mock_webhook:
+        await cog.on_command_error(ctx, error)
+
+    mock_webhook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_exception_triggers_webhook():
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    error = _make_http_exception(status=500)
+
+    with patch.object(
+        cog, "_send_error_webhook", new_callable=AsyncMock
+    ) as mock_webhook:
+        await cog.on_command_error(ctx, error)
+
+    mock_webhook.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_safe_respond_uses_interaction_followup():
+    """When interaction is done, should use interaction.followup.send."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+    ctx.interaction = MagicMock()
+    ctx.interaction.response.is_done.return_value = True
+    ctx.interaction.followup = AsyncMock()
+
+    await cog._safe_respond(ctx, "test message")
+
+    ctx.interaction.followup.send.assert_awaited_once_with(
+        "test message", ephemeral=True
+    )
+    ctx.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_safe_respond_uses_ctx_send_when_no_interaction():
+    """When no interaction, should fall back to ctx.send."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    await cog._safe_respond(ctx, "test message")
+
+    ctx.send.assert_awaited_once_with("test message")
+
+
+@pytest.mark.asyncio
+async def test_safe_respond_swallows_send_failure():
+    cog = _make_cog()
+    ctx = _make_ctx()
+    ctx.send.side_effect = discord.HTTPException(
+        response=MagicMock(status=404, headers={}), message="not found"
+    )
+
+    await cog._safe_respond(ctx, "test message")


### PR DESCRIPTION
## Summary

Fixes three issues with Discord rate-limit (429) handling:

1. **`bot.py`** — Set `max_ratelimit_timeout=60.0` on the `Bot`. Without this, discord.py blocks indefinitely when a route gets 429'd with no upper bound. Now the library handles short waits (≤60s) transparently, and raises `discord.RateLimited` for longer ones.

2. **`core.py`** — Fixed the restart loop. Two bugs:
   - `discord.RateLimited` was never caught — it doesn't subclass `HTTPException`, so it bypassed the handler entirely.
   - The existing 429 handler did `raise e` *after* sleeping, so the `while True` loop never actually retried — it just crashed after a wasted sleep.

   Now: `RateLimited` → sleep `retry_after` → `continue` (restart the bot connection).

3. **`error_handler.py`** — Added `discord.RateLimited` handler. Previously, rate limits during command execution fell through to the generic `else` branch, firing the error webhook + "An error occured" for a routine rate limit. Now shows a user-facing message with the retry time.

   Also fixed `ctx.followup` → `ctx.interaction.followup` — `Context` has no `followup` attribute (`AttributeError` at runtime). `Interaction` does.

## Changes

| File | Change |
|------|--------|
| `bot.py:19` | Added `max_ratelimit_timeout=60.0` to `Bot(...)` |
| `core.py:21-27` | New `except discord.RateLimited` with sleep + continue |
| `core.py:28-34` | Removed dead 429-via-HTTPException code; simplified logging |
| `error_handler.py:51-61` | New `RateLimited` branch before `HTTPException` |
| `error_handler.py:100` | `ctx.followup` → `ctx.interaction.followup` |

## Verification
- `uv run pytest test/bases/bot_detector/discord_bot` → **41 passed** (10 new)
- `uv run ruff check` → clean
- `uv run mypy` → no new errors (pre-existing `import-untyped` only)